### PR TITLE
Add AI-driven analysis summaries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ matplotlib>=3.7.0
 reportlab>=4.0.0
 streamlit_js_eval>=0.1.0
 plotly>=5.0.0
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- integrate OpenAI-based dashboard comments for KPI summaries
- add AI explanations for standard rate results
- include openai in requirements

## Testing
- `pytest -q --ignore=pages`


------
https://chatgpt.com/codex/tasks/task_e_68b5a1630e18832382b61349a8938346