### PR TITLE
Refine UI with McKinsey-inspired styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,24 +1,82 @@
 import streamlit as st
-from components import render_stepper, render_sidebar_nav
+
+from components import (
+    inject_mckinsey_style,
+    render_page_header,
+    render_sidebar_nav,
+    render_stepper,
+)
 
 st.set_page_config(page_title="賃率ダッシュボード", layout="wide")
 
+inject_mckinsey_style()
 render_sidebar_nav()
 
-st.title("製品賃率ダッシュボード")
-st.caption("📊 Excel（標賃 / R6.12）から賃率KPIを自動計算し、SKU別の達成状況を可視化します。")
+render_page_header(
+    "製品賃率ダッシュボード",
+    "Excel（標賃 / R6.12）から賃率KPIを自動計算し、SKU別の達成状況を可視化します。",
+    icon="📊",
+)
 
 # Progress stepper for wizard flow
 render_stepper(0)
 
-st.write("次のページから機能を選択してください。")
+st.markdown(
+    """
+    <div class="mck-card">
+        <h3>ダッシュボードの歩き方</h3>
+        <p>製品別の採算状況を McKinsey らしい視点で段階的に把握できるよう、
+        「インプット → 分析 → 感度検証」の順でナビゲートします。利用したい
+        ページを下記のカードから選択してください。</p>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
 
-c1, c2, c3 = st.columns(3)
-with c1:
-    st.page_link("pages/01_データ入力.py", label="① データ入力 & 取り込み", icon="📥")
-with c2:
-    st.page_link("pages/02_ダッシュボード.py", label="② ダッシュボード", icon="📊")
-with c3:
-    st.page_link("pages/03_標準賃率計算.py", label="③ 標準賃率 計算/感度分析", icon="🧮")
+features = [
+    {
+        "icon": "📥",
+        "title": "① データ入力 & 取り込み",
+        "description": "標賃・R6.12 Excel を取り込み、製品マスターと賃率前提を整理します。",
+        "path": "pages/01_データ入力.py",
+    },
+    {
+        "icon": "📊",
+        "title": "② ダッシュボード",
+        "description": "SKU別の達成状況や未達要因をビジュアルで俯瞰し、改善余地を発見します。",
+        "path": "pages/02_ダッシュボード.py",
+    },
+    {
+        "icon": "🧮",
+        "title": "③ 標準賃率 計算/感度分析",
+        "description": "前提値を調整し、必要賃率への影響と感度を素早く検証します。",
+        "path": "pages/03_標準賃率計算.py",
+    },
+]
 
-st.info("まずは『データ入力 & 取り込み』で Excel を読み込むか、サンプルを使用してください。")
+cols = st.columns(len(features))
+for col, feature in zip(cols, features):
+    with col:
+        st.markdown(
+            f"""
+            <div class=\"mck-feature-card\">
+                <div class=\"mck-feature-icon\">{feature['icon']}</div>
+                <div>
+                    <h4>{feature['title']}</h4>
+                    <p>{feature['description']}</p>
+                </div>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        st.page_link(feature["path"], label="ページを開く", icon="↗️")
+
+st.markdown(
+    """
+    <div class="mck-cta-banner">
+        <span>💡</span>
+        <strong>まずは『① データ入力 & 取り込み』で Excel を読み込むか、サンプルデータをご利用ください。</strong>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)

--- a/components.py
+++ b/components.py
@@ -1,34 +1,465 @@
+from typing import Optional
+
 import streamlit as st
+
+_STYLE_SESSION_KEY = "_mckinsey_style_injected"
+
+_MCKINSEY_STYLE = """
+<style>
+:root {
+    --mck-deep-blue: #0B1F3A;
+    --mck-steel-blue: #1C3D63;
+    --mck-accent: #00A3E0;
+    --mck-soft-blue: #E7EEF7;
+    --mck-page-bg: #F5F7FA;
+    --mck-text: #1F2937;
+}
+
+.stApp {
+    background-color: var(--mck-page-bg);
+    color: var(--mck-text);
+    font-family: "Helvetica Neue", "Noto Sans JP", sans-serif;
+}
+
+.stApp h1,
+.stApp h2,
+.stApp h3,
+.stApp h4 {
+    color: var(--mck-deep-blue);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.stApp p,
+.stApp label,
+.stApp span,
+.stApp li {
+    color: #324157;
+}
+
+.block-container {
+    padding-top: 2rem;
+    padding-bottom: 3rem;
+    max-width: 1200px;
+}
+
+.stApp a {
+    color: var(--mck-accent);
+}
+
+.mck-header-card {
+    display: flex;
+    align-items: center;
+    gap: 1.6rem;
+    padding: 2rem 2.4rem;
+    margin-bottom: 1.8rem;
+    border-radius: 20px;
+    background: linear-gradient(130deg, var(--mck-deep-blue) 0%, #13294B 55%, var(--mck-steel-blue) 100%);
+    color: #FFFFFF;
+    box-shadow: 0 28px 52px rgba(7, 23, 43, 0.35);
+}
+
+.mck-header-icon {
+    width: 68px;
+    height: 68px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.15);
+    display: grid;
+    place-items: center;
+    font-size: 2rem;
+    font-weight: 600;
+}
+
+.mck-header-card h1 {
+    margin: 0;
+    color: #FFFFFF;
+    font-size: 1.9rem;
+}
+
+.mck-header-subtitle {
+    margin: 0.3rem 0 0;
+    font-size: 1.05rem;
+    color: rgba(255, 255, 255, 0.88);
+}
+
+.mck-card {
+    background: #FFFFFF;
+    border-radius: 18px;
+    padding: 1.6rem 1.8rem;
+    border: 1px solid rgba(15, 37, 62, 0.08);
+    box-shadow: 0 26px 54px rgba(15, 23, 42, 0.08);
+    margin-bottom: 1.5rem;
+}
+
+.mck-card h3 {
+    margin-top: 0;
+    margin-bottom: 0.6rem;
+}
+
+.mck-feature-card {
+    background: #FFFFFF;
+    border-radius: 18px;
+    padding: 1.4rem 1.6rem;
+    border: 1px solid rgba(12, 34, 64, 0.08);
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.09);
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+    min-height: 220px;
+    position: relative;
+    overflow: hidden;
+}
+
+.mck-feature-icon {
+    width: 58px;
+    height: 58px;
+    border-radius: 16px;
+    background: rgba(0, 163, 224, 0.14);
+    color: var(--mck-accent);
+    display: grid;
+    place-items: center;
+    font-size: 1.6rem;
+}
+
+.mck-feature-card h4 {
+    margin: 0;
+    font-size: 1.15rem;
+    color: var(--mck-deep-blue);
+}
+
+.mck-feature-card p {
+    margin: 0;
+    color: #4B5C73;
+    line-height: 1.55;
+    font-size: 0.95rem;
+}
+
+a[data-testid="stPageLink"],
+a[data-testid="stPageLink-NavLink"] {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 1.15rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    margin-top: 0.75rem;
+    background: rgba(0, 163, 224, 0.12);
+    color: var(--mck-deep-blue);
+    transition: all 0.2s ease-in-out;
+}
+
+a[data-testid="stPageLink"]:hover,
+a[data-testid="stPageLink-NavLink"]:hover {
+    background: linear-gradient(120deg, rgba(0, 163, 224, 0.18), rgba(11, 31, 58, 0.18));
+    color: var(--mck-deep-blue);
+    transform: translateY(-1px);
+}
+
+.mck-stepper {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.6rem;
+    margin: 1.6rem 0 1rem;
+    position: relative;
+}
+
+.mck-stepper .step {
+    text-align: center;
+    position: relative;
+    padding: 0.4rem 0.6rem 0.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    align-items: center;
+}
+
+.mck-stepper .step::before {
+    content: "";
+    position: absolute;
+    top: 19px;
+    left: -50%;
+    width: 100%;
+    height: 2px;
+    background: #D5DEEA;
+    z-index: 0;
+}
+
+.mck-stepper .step:first-child::before {
+    display: none;
+}
+
+.mck-stepper .circle {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+    font-size: 1rem;
+    box-shadow: 0 12px 20px rgba(15, 23, 42, 0.12);
+    z-index: 1;
+}
+
+.mck-stepper .label {
+    font-size: 0.9rem;
+    color: #4A5D75;
+    font-weight: 500;
+}
+
+.mck-stepper .step.done::before {
+    background: linear-gradient(90deg, var(--mck-deep-blue), var(--mck-accent));
+}
+
+.mck-stepper .step.done .circle {
+    background: var(--mck-deep-blue);
+    color: #FFFFFF;
+}
+
+.mck-stepper .step.active::before {
+    background: linear-gradient(90deg, var(--mck-deep-blue), var(--mck-accent));
+}
+
+.mck-stepper .step.active .circle {
+    background: var(--mck-accent);
+    color: #FFFFFF;
+}
+
+.mck-stepper .step.upcoming .circle {
+    background: #FFFFFF;
+    border: 2px solid #CBD5E1;
+    color: #7A889C;
+}
+
+div[data-testid="stMetric"] {
+    background: #FFFFFF;
+    border-radius: 16px;
+    border: 1px solid rgba(15, 37, 62, 0.08);
+    box-shadow: 0 26px 52px rgba(15, 23, 42, 0.08);
+    padding: 1.2rem 1.4rem;
+}
+
+div[data-testid="stMetric"] label {
+    text-transform: uppercase;
+    color: #74859D;
+    font-size: 0.75rem;
+    letter-spacing: 0.06em;
+}
+
+div[data-testid="stMetric"] [data-testid="stMetricValue"] {
+    color: var(--mck-deep-blue);
+    font-size: 1.5rem;
+    font-weight: 700;
+}
+
+div[data-testid="stMetric"] [data-testid="stMetricDelta"] {
+    font-weight: 600;
+}
+
+div[data-testid="stDataFrame"] {
+    border-radius: 18px;
+    border: 1px solid rgba(15, 37, 62, 0.08);
+    box-shadow: 0 24px 50px rgba(15, 23, 42, 0.08);
+    overflow: hidden;
+}
+
+details {
+    border-radius: 16px !important;
+    border: 1px solid rgba(15, 37, 62, 0.08) !important;
+    padding: 0.75rem 1rem !important;
+    background: #FFFFFF !important;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08) !important;
+}
+
+details[open] {
+    border-color: rgba(0, 163, 224, 0.3) !important;
+}
+
+details summary {
+    font-weight: 600;
+    color: var(--mck-deep-blue);
+}
+
+.stButton > button,
+.stFormSubmitButton > button {
+    background: linear-gradient(120deg, var(--mck-deep-blue), var(--mck-steel-blue));
+    color: #FFFFFF;
+    border-radius: 12px;
+    border: none;
+    font-weight: 600;
+    padding: 0.6rem 1.3rem;
+    box-shadow: 0 20px 32px rgba(15, 37, 62, 0.24);
+    transition: all 0.2s ease-in-out;
+}
+
+.stButton > button:hover,
+.stFormSubmitButton > button:hover {
+    background: linear-gradient(120deg, var(--mck-deep-blue), var(--mck-accent));
+    box-shadow: 0 22px 36px rgba(15, 37, 62, 0.28);
+    transform: translateY(-1px);
+}
+
+[data-testid="stSidebar"] {
+    background: #FFFFFF;
+    border-right: 1px solid rgba(15, 37, 62, 0.08);
+    padding: 1.6rem 1.2rem 2rem;
+}
+
+[data-testid="stSidebar"] h1,
+[data-testid="stSidebar"] h2,
+[data-testid="stSidebar"] h3 {
+    color: var(--mck-deep-blue);
+}
+
+[data-testid="stSidebar"] .stButton > button,
+[data-testid="stSidebar"] .stFormSubmitButton > button {
+    width: 100%;
+}
+
+.mck-sidebar-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 1.4rem;
+}
+
+.mck-sidebar-header span {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--mck-deep-blue);
+    letter-spacing: 0.05em;
+}
+
+.mck-sidebar-header p {
+    margin: 0;
+    color: #5B6C82;
+    font-size: 0.85rem;
+}
+
+.mck-sidebar-footer {
+    margin-top: 2rem;
+    font-size: 0.75rem;
+    color: #8391A6;
+}
+
+.mck-cta-banner {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.3rem;
+    border-radius: 16px;
+    background: rgba(0, 163, 224, 0.08);
+    border: 1px solid rgba(0, 163, 224, 0.18);
+    color: var(--mck-deep-blue);
+}
+
+.mck-cta-banner strong {
+    font-size: 0.95rem;
+}
+
+.mck-cta-banner span {
+    font-size: 1.4rem;
+}
+
+@media (max-width: 992px) {
+    .block-container {
+        padding: 1.4rem 1rem 2.5rem;
+    }
+
+    .mck-header-card {
+        flex-direction: column;
+        align-items: flex-start;
+        text-align: left;
+    }
+
+    .mck-header-icon {
+        width: 56px;
+        height: 56px;
+        font-size: 1.6rem;
+    }
+
+    .mck-feature-card {
+        min-height: auto;
+    }
+}
+</style>
+"""
+
+
+def inject_mckinsey_style() -> None:
+    """Inject bespoke CSS to give the app a McKinsey-inspired aesthetic."""
+
+    if st.session_state.get(_STYLE_SESSION_KEY):
+        return
+    st.markdown(_MCKINSEY_STYLE, unsafe_allow_html=True)
+    st.session_state[_STYLE_SESSION_KEY] = True
+
+
+def render_page_header(title: str, subtitle: str = "", icon: Optional[str] = None) -> None:
+    """Render a hero-style header block used across pages."""
+
+    inject_mckinsey_style()
+    icon_html = f"<div class='mck-header-icon'>{icon}</div>" if icon else ""
+    subtitle_html = f"<p class='mck-header-subtitle'>{subtitle}</p>" if subtitle else ""
+    st.markdown(
+        f"""
+        <div class="mck-header-card">
+            {icon_html}
+            <div class="mck-header-copy">
+                <h1>{title}</h1>
+                {subtitle_html}
+            </div>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
 
 
 def render_stepper(current_step: int) -> None:
-    """Render a simple progress stepper for the import wizard.
+    """Render a stylised progress stepper for the workflow."""
 
-    Parameters
-    ----------
-    current_step: int
-        Zero-based index of the current step. The wizard steps are::
-
-            0: ホーム
-            1: 取り込み
-            2: 自動検証
-            3: 結果サマリ
-            4: ダッシュボード
-    """
+    inject_mckinsey_style()
     steps = ["ホーム", "取り込み", "自動検証", "結果サマリ", "ダッシュボード"]
-    total = len(steps) - 1
-    progress = min(max(current_step, 0), total) / total if total else 0.0
-    st.progress(progress)
-    cols = st.columns(len(steps))
-    for idx, (col, label) in enumerate(zip(cols, steps)):
-        prefix = "🔵" if idx <= current_step else "⚪️"
-        col.markdown(f"{prefix} {label}")
+    step_markup = []
+    for idx, label in enumerate(steps):
+        if idx < current_step:
+            status = "done"
+        elif idx == current_step:
+            status = "active"
+        else:
+            status = "upcoming"
+        step_markup.append(
+            f"""
+            <div class="step {status}">
+                <div class="circle">{idx + 1}</div>
+                <div class="label">{label}</div>
+            </div>
+            """
+        )
+    st.markdown(f"<div class='mck-stepper'>{''.join(step_markup)}</div>", unsafe_allow_html=True)
 
 
 def render_sidebar_nav() -> None:
-    """Render sidebar navigation links across pages."""
-    st.sidebar.header("ナビゲーション")
-    st.sidebar.page_link("app.py", label="ホーム", icon="🏠")
-    st.sidebar.page_link("pages/01_データ入力.py", label="① データ入力", icon="📥")
-    st.sidebar.page_link("pages/02_ダッシュボード.py", label="② ダッシュボード", icon="📊")
-    st.sidebar.page_link("pages/03_標準賃率計算.py", label="③ 標準賃率計算", icon="🧮")
+    """Render sidebar navigation links across pages with refined styling."""
+
+    inject_mckinsey_style()
+    with st.sidebar:
+        st.markdown(
+            """
+            <div class="mck-sidebar-header">
+                <span>ナビゲーション</span>
+                <p>分析したいステップを選択してください。</p>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
+        st.page_link("app.py", label="ホーム", icon="🏠")
+        st.page_link("pages/01_データ入力.py", label="① データ入力", icon="📥")
+        st.page_link("pages/02_ダッシュボード.py", label="② ダッシュボード", icon="📊")
+        st.page_link("pages/03_標準賃率計算.py", label="③ 標準賃率計算", icon="🧮")
+        st.markdown(
+            """
+            <div class="mck-sidebar-footer">Powered by 製品賃率ダッシュボード</div>
+            """,
+            unsafe_allow_html=True,
+        )

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 [theme]
 base="light"
-primaryColor="#4E79A7"
-backgroundColor="#F9FAFB"
+primaryColor="#00A3E0"
+backgroundColor="#F5F7FA"
 secondaryBackgroundColor="#FFFFFF"
-textColor="#333333"
+textColor="#0B1F3A"
 font="sans serif"

--- a/pages/01_データ入力.py
+++ b/pages/01_データ入力.py
@@ -5,10 +5,20 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import streamlit as st
 import pandas as pd
 from utils import read_excel_safely, parse_hyochin, parse_products
-from components import render_stepper, render_sidebar_nav
+from components import (
+    inject_mckinsey_style,
+    render_page_header,
+    render_sidebar_nav,
+    render_stepper,
+)
 
-st.title("① データ入力 & 取り込み")
+inject_mckinsey_style()
 render_sidebar_nav()
+render_page_header(
+    "① データ入力 & 取り込み",
+    "Excel から標賃と製品データを取り込み、分析シナリオのベースラインを整えます。",
+    icon="📥",
+)
 render_stepper(1)
 
 default_path = "data/sample.xlsx"

--- a/pages/02_ダッシュボード.py
+++ b/pages/02_ダッシュボード.py
@@ -13,7 +13,12 @@ from urllib.parse import urlencode
 
 from utils import compute_results, detect_quality_issues
 from standard_rate_core import DEFAULT_PARAMS, sanitize_params, compute_rates
-from components import render_stepper, render_sidebar_nav
+from components import (
+    inject_mckinsey_style,
+    render_page_header,
+    render_sidebar_nav,
+    render_stepper,
+)
 import os
 from typing import Dict
 
@@ -41,8 +46,13 @@ def _generate_dashboard_comment(df: pd.DataFrame, metrics: Dict[str, float]) -> 
     except Exception as exc:
         return f"AIコメント生成に失敗しました: {exc}"
 
-st.title("② ダッシュボード")
+inject_mckinsey_style()
 render_sidebar_nav()
+render_page_header(
+    "② ダッシュボード",
+    "KPI 達成状況や未達の要因を多角的に把握し、優先すべき SKU を明確にします。",
+    icon="📊",
+)
 render_stepper(4)
 scenario_name = st.session_state.get("current_scenario", "ベース")
 st.caption(f"適用中シナリオ: {scenario_name}")

--- a/pages/03_標準賃率計算.py
+++ b/pages/03_標準賃率計算.py
@@ -7,7 +7,12 @@ import streamlit as st
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
-from components import render_stepper, render_sidebar_nav
+from components import (
+    inject_mckinsey_style,
+    render_page_header,
+    render_sidebar_nav,
+    render_stepper,
+)
 import os
 from openai import OpenAI
 
@@ -37,8 +42,13 @@ from standard_rate_core import (
     generate_pdf,
 )
 
-st.title("③ 標準賃率 計算/感度分析")
+inject_mckinsey_style()
 render_sidebar_nav()
+render_page_header(
+    "③ 標準賃率 計算/感度分析",
+    "コスト前提と操業条件を調整し、必要賃率への感度を数値・グラフで検証します。",
+    icon="🧮",
+)
 render_stepper(4)
 scenarios = st.session_state.setdefault("scenarios", {"ベース": st.session_state.get("sr_params", DEFAULT_PARAMS)})
 current = st.session_state.setdefault("current_scenario", "ベース")


### PR DESCRIPTION
## Summary
- add a reusable McKinsey-inspired style layer with hero headers, feature cards, and updated stepper navigation
- refresh the landing page layout with descriptive cards and CTA messaging aligned to the new aesthetic
- update Streamlit theme colors to a deep navy and teal palette for a consulting-grade look

## Testing
- pytest *(fails: import mismatch caused by duplicate test module names under `pages/data/`)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9dfb990083238f4b044afa100b0c