### PR TITLE
Fix dashboard import to prioritize local utils module

### DIFF
--- a/pages/02_ダッシュボード.py
+++ b/pages/02_ダッシュボード.py
@@ -1,6 +1,10 @@
 import sys
 from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    # Ensure our project root takes precedence so we import the local utils module
+    # instead of any similarly named third-party package that might exist.
+    sys.path.insert(0, str(BASE_DIR))
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
## Summary
- ensure the dashboard page adds the project root to sys.path ahead of third-party packages so the local utils module is imported

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cab0fd41088323b913e2fd30597637