### PR TITLE
Add sidebar layout helper

### DIFF
--- a/ui_layout.py
+++ b/ui_layout.py
@@ -1,0 +1,8 @@
+import streamlit as st
+
+
+def sidebar_steps():
+    st.sidebar.header("メニュー")
+    use_new = st.sidebar.toggle("新UIを試す", value=True, help="不具合時はOFFで旧UIに戻せます")
+    step = st.sidebar.radio("ステップ", ["① データ", "② 設定", "③ 結果", "④ 書き出し"], index=0)
+    return use_new, step


### PR DESCRIPTION
## Summary
- add a `sidebar_steps` helper that renders the sidebar menu with a new UI toggle and step selector

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce95d81ae0832383943744a3ad6d38