### PR TITLE
Add reusable table and KPI UI widgets

### DIFF
--- a/ui_layout.py
+++ b/ui_layout.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import streamlit as st
 
 
@@ -6,3 +8,16 @@ def sidebar_steps():
     use_new = st.sidebar.toggle("新UIを試す", value=True, help="不具合時はOFFで旧UIに戻せます")
     step = st.sidebar.radio("ステップ", ["① データ", "② 設定", "③ 結果", "④ 書き出し"], index=0)
     return use_new, step
+
+
+def kpi_card(label: str, value, delta=None, help: Optional[str] = None) -> None:
+    """Display a KPI block with optional delta and help text."""
+
+    with st.container(border=True):
+        st.caption(label)
+        cols = st.columns([2, 1])
+        cols[0].markdown(f"### {value}")
+        if delta is not None:
+            cols[1].metric(label="", value="", delta=delta)
+        if help:
+            st.caption(f"ℹ️ {help}")

--- a/ui_widgets.py
+++ b/ui_widgets.py
@@ -1,0 +1,51 @@
+"""Reusable Streamlit UI widgets for the product rate app."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pandas as pd
+import streamlit as st
+
+
+__all__ = ["table_block"]
+
+
+def table_block(df: pd.DataFrame, name: str = "result") -> None:
+    """Render a dataframe with download actions for CSV and Excel formats.
+
+    Parameters
+    ----------
+    df:
+        The pandas ``DataFrame`` to display in Streamlit.
+    name:
+        Base filename used for the export buttons.
+    """
+
+    st.dataframe(
+        df,
+        use_container_width=True,
+        column_config={
+            "amount": st.column_config.NumberColumn("金額", format="¥,d"),
+            "rate": st.column_config.NumberColumn("率", format="%.2f%%"),
+            "date": st.column_config.DateColumn("日付"),
+        },
+    )
+
+    csv = df.to_csv(index=False).encode("utf-8-sig")
+    st.download_button(
+        "CSVダウンロード",
+        csv,
+        file_name=f"{name}.csv",
+        mime="text/csv",
+    )
+
+    buf = BytesIO()
+    with pd.ExcelWriter(buf, engine="xlsxwriter") as writer:
+        df.to_excel(writer, sheet_name="data", index=False)
+    st.download_button(
+        "Excelダウンロード",
+        buf.getvalue(),
+        file_name=f"{name}.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )


### PR DESCRIPTION
## Summary
- add a reusable table_block helper that renders dataframes and export buttons
- extend the layout helpers with a KPI card container for metric display

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce98d761b88323ba6d32a0c8415e49