### PR TITLE
Add offline caching and responsive layout improvements

### DIFF
--- a/components.py
+++ b/components.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, List, Optional
 
 import streamlit as st
 
+from offline import render_offline_controls
+
 _DEFAULT_THEME_KEY = "標準（ブルー）"
 _DEFAULT_FONT_KEY = "ふつう"
 
@@ -341,6 +343,54 @@ def _build_theme_css(theme: Dict[str, str], font_scale: float) -> str:
         color: var(--app-accent);
         font-weight: 600;
     }}
+    @media (max-width: 1080px) {{
+        [data-testid="stSidebar"] {{
+            width: 280px;
+        }}
+        .stButton > button,
+        .stDownloadButton > button {{
+            width: 100%;
+        }}
+    }}
+    @media (max-width: 860px) {{
+        [data-testid="stAppViewContainer"] {{
+            padding-left: 0;
+            padding-right: 0;
+        }}
+        [data-testid="block-container"] {{
+            padding: 0.6rem 0.9rem 3rem;
+        }}
+        [data-testid="stHorizontalBlock"] {{
+            flex-wrap: wrap;
+            gap: 0.75rem;
+        }}
+        [data-testid="stHorizontalBlock"] > div {{
+            flex: 1 1 100% !important;
+            width: 100% !important;
+        }}
+        div[data-testid="column"] {{
+            flex: 1 1 100% !important;
+            width: 100% !important;
+        }}
+        [data-testid="stMetric"] {{
+            width: 100%;
+        }}
+        .stTabs [data-baseweb="tab-list"] {{
+            flex-wrap: wrap;
+        }}
+    }}
+    @media (max-width: 520px) {{
+        h1 {{
+            font-size: calc(var(--app-font-base) * 1.4);
+        }}
+        h2 {{
+            font-size: calc(var(--app-font-base) * 1.25);
+        }}
+        .stButton > button,
+        .stDownloadButton > button {{
+            padding: 0.55rem 1.0rem;
+        }}
+    }}
     </style>
     """
 
@@ -571,3 +621,6 @@ def render_sidebar_nav(*, page_key: Optional[str] = None) -> None:
     )
 
     st.sidebar.caption(_ONBOARDING_EFFECT)
+
+    st.sidebar.divider()
+    render_offline_controls()

--- a/offline.py
+++ b/offline.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+try:  # pragma: no cover - streamlit is optional during unit tests
+    import streamlit as st
+except ModuleNotFoundError:  # pragma: no cover - allows running tests without Streamlit
+    st = None  # type: ignore
+
+try:  # pragma: no cover - the JS bridge is optional for tests
+    from streamlit_js_eval import streamlit_js_eval
+except ModuleNotFoundError:  # pragma: no cover - degrade gracefully when not installed
+    streamlit_js_eval = None  # type: ignore
+
+_STORAGE_KEY = "rate_app_cache_v1"
+_FLAG_KEY = "offline_cache_enabled"
+_AVAILABLE_KEY = "_offline_cache_available"
+_TIMESTAMP_KEY = "offline_cache_timestamp"
+_NOTICE_KEY = "_offline_restore_notified"
+_JS_KEY_PREFIX = "offline_cache"
+
+
+def _call_js(expression: str, suffix: str) -> Optional[Any]:
+    """Execute ``expression`` in the browser via :mod:`streamlit_js_eval`."""
+
+    if streamlit_js_eval is None:  # pragma: no cover - JS bridge unavailable during tests
+        return None
+    key = f"{_JS_KEY_PREFIX}_{suffix}"
+    try:
+        return streamlit_js_eval(js_expressions=expression, key=key)
+    except Exception:  # pragma: no cover - runtime JS errors should not crash the app
+        return None
+
+
+def ensure_offline_state_defaults() -> None:
+    """Initialise the session state keys used by the offline helpers."""
+
+    if st is None:  # pragma: no cover - streamlit not imported in tests
+        return
+    st.session_state.setdefault(_FLAG_KEY, True)
+    st.session_state.setdefault(_AVAILABLE_KEY, False)
+    st.session_state.setdefault(_TIMESTAMP_KEY, None)
+    st.session_state.setdefault(_NOTICE_KEY, False)
+
+
+def _build_payload() -> Optional[Dict[str, Any]]:
+    """Serialise the current session data into a JSON-friendly payload."""
+
+    if st is None:
+        return None
+    df = st.session_state.get("df_products_raw")
+    if df is None or not isinstance(df, pd.DataFrame):
+        return None
+
+    products = df.where(pd.notnull(df), None).to_dict(orient="records")
+    timestamp = datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    payload: Dict[str, Any] = {
+        "timestamp": timestamp,
+        "sr_params": st.session_state.get("sr_params", {}),
+        "calc_params": st.session_state.get("calc_params", {}),
+        "scenarios": st.session_state.get("scenarios", {}),
+        "current_scenario": st.session_state.get("current_scenario"),
+        "using_sample_data": st.session_state.get("using_sample_data", False),
+        "products": products,
+    }
+    return payload
+
+
+def load_offline_cache() -> Optional[Dict[str, Any]]:
+    """Return the cached payload stored in the browser, if any."""
+
+    if st is None:
+        return None
+    ensure_offline_state_defaults()
+    if streamlit_js_eval is None:  # pragma: no cover - offline mode unavailable during tests
+        st.session_state[_AVAILABLE_KEY] = False
+        return None
+
+    raw = _call_js(f"window.localStorage.getItem('{_STORAGE_KEY}')", "get")
+    if not raw:
+        st.session_state[_AVAILABLE_KEY] = False
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        st.session_state[_AVAILABLE_KEY] = False
+        return None
+    if isinstance(payload, dict):
+        st.session_state[_AVAILABLE_KEY] = True
+    return payload
+
+
+def restore_session_state_from_cache() -> bool:
+    """Populate :mod:`streamlit` session state from the offline cache."""
+
+    if st is None:
+        return False
+    ensure_offline_state_defaults()
+    if st.session_state.get("df_products_raw") is not None:
+        return False
+
+    payload = load_offline_cache()
+    if not payload:
+        return False
+
+    try:
+        records = payload.get("products", [])
+        df_products = pd.DataFrame(records)
+    except Exception:
+        return False
+
+    st.session_state["df_products_raw"] = df_products
+    st.session_state["sr_params"] = payload.get("sr_params", {})
+    st.session_state["calc_params"] = payload.get("calc_params", {})
+    scenarios = payload.get("scenarios")
+    if isinstance(scenarios, dict):
+        st.session_state["scenarios"] = scenarios
+    current = payload.get("current_scenario")
+    if current:
+        st.session_state["current_scenario"] = current
+    st.session_state["using_sample_data"] = payload.get("using_sample_data", False)
+    timestamp = payload.get("timestamp")
+    if isinstance(timestamp, str):
+        st.session_state[_TIMESTAMP_KEY] = timestamp
+    else:
+        st.session_state[_TIMESTAMP_KEY] = None
+    st.session_state[_AVAILABLE_KEY] = True
+    st.session_state[_NOTICE_KEY] = False
+    return True
+
+
+def sync_offline_cache() -> None:
+    """Persist the latest session snapshot to the browser cache."""
+
+    if st is None:
+        return
+    ensure_offline_state_defaults()
+    if not st.session_state.get(_FLAG_KEY, False):
+        return
+    if streamlit_js_eval is None:  # pragma: no cover - JS bridge unavailable during tests
+        return
+
+    payload = _build_payload()
+    if payload is None:
+        return
+
+    payload_json = json.dumps(payload, ensure_ascii=False)
+    _call_js(
+        f"window.localStorage.setItem('{_STORAGE_KEY}', JSON.stringify({payload_json}))",
+        "set",
+    )
+    st.session_state[_AVAILABLE_KEY] = True
+    st.session_state[_TIMESTAMP_KEY] = payload["timestamp"]
+
+
+def clear_offline_cache() -> None:
+    """Delete the stored snapshot from the browser."""
+
+    if st is None:
+        return
+    ensure_offline_state_defaults()
+    if streamlit_js_eval is not None:
+        _call_js(f"window.localStorage.removeItem('{_STORAGE_KEY}')", "clear")
+    st.session_state[_AVAILABLE_KEY] = False
+    st.session_state[_TIMESTAMP_KEY] = None
+
+
+def render_offline_controls() -> None:
+    """Display sidebar controls for managing offline caching."""
+
+    if st is None:
+        return
+    ensure_offline_state_defaults()
+
+    container = st.sidebar
+    container.subheader("オフラインモード")
+    container.caption(
+        "通信が不安定な環境でも閲覧できるよう、ブラウザに最新データを保存します。"
+    )
+
+    js_ready = streamlit_js_eval is not None
+    enabled = container.toggle(
+        "端末に最新版をキャッシュ",
+        key=_FLAG_KEY,
+        help="ONにすると取り込んだExcelやシナリオ設定をブラウザに保存します。",
+        disabled=not js_ready,
+    )
+    if not js_ready:
+        container.caption("ブラウザ連携ライブラリが利用できないため保存機能は無効です。")
+        return
+
+    timestamp = st.session_state.get(_TIMESTAMP_KEY)
+    available = st.session_state.get(_AVAILABLE_KEY, False)
+    if enabled and available and timestamp:
+        container.caption(f"最終保存: {timestamp}")
+    elif enabled and not available:
+        container.caption("データを読み込むと自動的に保存されます。")
+    else:
+        container.caption("OFFにすると端末には保存されません。")
+
+    if container.button(
+        "保存済みデータを削除",
+        key="offline_cache_clear",
+        use_container_width=True,
+        disabled=not available,
+        help="端末に保存したデータを削除します。",
+    ):
+        clear_offline_cache()
+        toast = getattr(st, "toast", None)
+        if callable(toast):
+            toast("ローカルキャッシュを削除しました。")
+        else:
+            container.success("ローカルキャッシュを削除しました。")
+
+
+def should_show_restore_notice() -> bool:
+    """Return ``True`` when the offline restore notice should be displayed."""
+
+    if st is None:
+        return False
+    ensure_offline_state_defaults()
+    return not bool(st.session_state.get(_NOTICE_KEY))
+
+
+def mark_restore_notice_shown() -> None:
+    """Record that the offline restore notice has been shown this session."""
+
+    if st is None:
+        return
+    ensure_offline_state_defaults()
+    st.session_state[_NOTICE_KEY] = True

--- a/pages/01_データ入力.py
+++ b/pages/01_データ入力.py
@@ -33,6 +33,12 @@ from components import (
     render_stepper,
     render_sidebar_nav,
 )
+from offline import (
+    mark_restore_notice_shown,
+    restore_session_state_from_cache,
+    should_show_restore_notice,
+    sync_offline_cache,
+)
 
 apply_user_theme()
 
@@ -43,6 +49,19 @@ render_help_button("data")
 render_onboarding()
 render_page_tutorial("data")
 render_stepper(1)
+
+restored_from_cache = False
+if "df_products_raw" not in st.session_state:
+    restored_from_cache = restore_session_state_from_cache()
+
+if restored_from_cache and should_show_restore_notice():
+    timestamp = st.session_state.get("offline_cache_timestamp")
+    if timestamp:
+        st.success(f"ブラウザに保存していた {timestamp} 時点のデータを復元しました。")
+    else:
+        st.success("ブラウザに保存していた直近のデータを復元しました。")
+    st.caption("通信が不安定な環境でもサイドバーの『オフラインモード』から最新版を更新できます。")
+    mark_restore_notice_shown()
 
 st.subheader("Excelテンプレート")
 st.markdown(
@@ -409,3 +428,5 @@ if history:
         st.dataframe(history_df, use_container_width=True)
 
 st.success("保存しました。上部のナビから『ダッシュボード』へ進んでください。")
+
+sync_offline_cache()

--- a/pages/02_ダッシュボード.py
+++ b/pages/02_ダッシュボード.py
@@ -34,6 +34,7 @@ from components import (
     render_stepper,
     render_sidebar_nav,
 )
+from offline import restore_session_state_from_cache, sync_offline_cache
 import os
 from typing import Dict, Any, List, Optional, Tuple
 
@@ -85,6 +86,8 @@ _PASTEL_THEME_CONFIG["config"]["legend"]["titleColor"] = _palette["text"]
 
 
 apply_user_theme()
+
+restore_session_state_from_cache()
 
 
 def _register_pastel_theme() -> None:
@@ -2508,3 +2511,5 @@ with tabs[5]:
         tooltip=["count()"]
     ).properties(height=420)
     st.altair_chart(hist, use_container_width=True)
+
+sync_offline_cache()

--- a/pages/03_標準賃率計算.py
+++ b/pages/03_標準賃率計算.py
@@ -16,6 +16,7 @@ from components import (
 import os
 from textwrap import dedent
 from openai import OpenAI
+from offline import restore_session_state_from_cache, sync_offline_cache
 
 
 def _explain_standard_rate(
@@ -232,6 +233,8 @@ from standard_rate_core import (
 )
 
 apply_user_theme()
+
+restore_session_state_from_cache()
 
 st.title("③ 標準賃率 計算/感度分析")
 render_sidebar_nav(page_key="standard_rate")
@@ -656,3 +659,5 @@ st.download_button("CSVエクスポート", data=csv, file_name=f"standard_rate_
 
 pdf_bytes = generate_pdf(nodes, fig)
 st.download_button("PDFエクスポート", data=pdf_bytes, file_name=f"standard_rate_summary__{current}.pdf", mime="application/pdf")
+
+sync_offline_cache()

--- a/pages/04_チャットサポート.py
+++ b/pages/04_チャットサポート.py
@@ -16,6 +16,7 @@ from components import (
     render_page_tutorial,
     render_sidebar_nav,
 )
+from offline import restore_session_state_from_cache, sync_offline_cache
 from standard_rate_core import DEFAULT_PARAMS, compute_rates, sanitize_params
 from utils import (
     compute_results,
@@ -397,6 +398,8 @@ def _prepare_context() -> tuple[pd.DataFrame, Dict[str, float], str]:
 
 
 apply_user_theme()
+
+restore_session_state_from_cache()
 render_sidebar_nav(page_key="chat")
 st.title("④ チャットボット / FAQ")
 render_help_button("chat")
@@ -482,3 +485,5 @@ for message in history:
     content = message.get("content", "")
     with st.chat_message(role):
         st.markdown(content)
+
+sync_offline_cache()


### PR DESCRIPTION
## Summary
- add an offline cache helper that syncs session data to browser storage and expose the controls in the sidebar
- restore cached data automatically on feature pages and push updates back to the cache after each workflow
- tweak the shared CSS to stack columns and widen buttons for a better mobile experience

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2037cef4c83238da45de70efb7a71