### PR TITLE
Enhance anomaly classification workflow and data quality guidance

### DIFF
--- a/test_quality.py
+++ b/test_quality.py
@@ -74,7 +74,7 @@ def test_validate_product_dataframe_detects_unit_mismatch():
     errors, warnings, detail = validate_product_dataframe(df)
     assert any("単位" in msg for msg in errors)
     target = detail[detail["項目"] == "販売単価（円/個）"].iloc[0]
-    assert "千円/個" in str(target["内容"]) or "千円/個" in str(target["入力値"])
+    assert "千円/個" in str(target["原因/状況"]) or "千円/個" in str(target["入力値"])
     assert "テンプレート" in str(target["対処方法"])
 
 
@@ -102,7 +102,7 @@ def test_validate_product_dataframe_warns_when_unit_missing():
     assert not errors
     assert any("リードタイム" in msg for msg in warnings)
     dataset_issue = detail[detail["項目"] == "リードタイム（分/個）"].iloc[0]
-    assert "未設定" in str(dataset_issue["内容"])
+    assert "未設定" in str(dataset_issue["原因/状況"])
     assert "分/個" in str(dataset_issue["対処方法"])
 
 


### PR DESCRIPTION
## Summary
- add explicit anomaly classification options (例外的な値・誤入力・要調査) and persist selections with descriptive history sections
- refresh anomaly review UI to surface classification guidance, memo support and corrected value handling while migrating legacy decisions
- enrich data quality validation output with concrete causes and default remediation hints for each row, updating tests accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d2435101a88323af6606602fc15d52