### PR TITLE
Add benchmark support to chat assistant

### DIFF
--- a/pages/04_チャットサポート.py
+++ b/pages/04_チャットサポート.py
@@ -4,7 +4,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import re
-from typing import Dict, Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 import streamlit as st
@@ -63,6 +63,18 @@ def _format_currency(value: Any, unit: str, digits: int = 0) -> str:
     return _format_number(value, unit, digits)
 
 
+def _format_percent(value: Any, digits: int = 1) -> str:
+    if value in (None, ""):
+        return "データ未設定"
+    try:
+        val = float(value)
+    except (TypeError, ValueError):
+        return "データ未設定"
+    if pd.isna(val):
+        return "データ未設定"
+    return f"{val:.{digits}f}%"
+
+
 def _count_meets_required(df: Optional[pd.DataFrame]) -> int:
     if df is None or df.empty:
         return 0
@@ -78,6 +90,91 @@ def _count_meets_required(df: Optional[pd.DataFrame]) -> int:
         else:
             meets = pd.to_numeric(meets_series, errors="coerce") > 0
     return int(meets.fillna(False).sum())
+
+
+def _normalize_label(value: Any, default: str = "未設定") -> str:
+    if value in (None, ""):
+        return default
+    if isinstance(value, str):
+        text = value.strip()
+    else:
+        text = str(value).strip()
+    if not text or text.lower() in {"nan", "none"}:
+        return default
+    return text
+
+
+def _compute_benchmarks(df: Optional[pd.DataFrame]) -> Dict[str, Any]:
+    if df is None or df.empty:
+        return {"overall": {}, "by_category": {}, "by_customer": {}}
+
+    def _safe_mean(series: pd.Series) -> float:
+        numeric = pd.to_numeric(series, errors="coerce").dropna()
+        if numeric.empty:
+            return float("nan")
+        return float(numeric.mean())
+
+    def _safe_quantile(series: pd.Series, q: float) -> float:
+        numeric = pd.to_numeric(series, errors="coerce").dropna()
+        if numeric.empty:
+            return float("nan")
+        return float(numeric.quantile(q))
+
+    def _safe_ach(series: pd.Series) -> float:
+        if series is None or series.empty:
+            return float("nan")
+        work = series
+        if work.dtype != bool:
+            work = pd.to_numeric(work, errors="coerce").fillna(0) > 0
+        return float(work.mean() * 100.0)
+
+    def _calc_metrics(sub: pd.DataFrame) -> Dict[str, float]:
+        actual = pd.to_numeric(sub.get("actual_unit_price"), errors="coerce")
+        required = pd.to_numeric(sub.get("required_selling_price"), errors="coerce")
+        price_gap = pd.to_numeric(sub.get("price_gap_vs_required"), errors="coerce")
+        rate_gap = pd.to_numeric(sub.get("rate_gap_vs_required"), errors="coerce")
+        va_per_min = pd.to_numeric(sub.get("va_per_min"), errors="coerce")
+        raise_needed = (required - actual).where((required - actual) > 0)
+        return {
+            "sku_count": int(len(sub)),
+            "avg_actual_price": _safe_mean(actual),
+            "avg_required_price": _safe_mean(required),
+            "avg_price_gap": _safe_mean(price_gap),
+            "avg_raise_needed": _safe_mean(raise_needed),
+            "avg_rate_gap": _safe_mean(rate_gap),
+            "avg_va_per_min": _safe_mean(va_per_min),
+            "top_quartile_actual_price": _safe_quantile(actual, 0.75),
+            "top_quartile_va_per_min": _safe_quantile(va_per_min, 0.75),
+            "ach_rate_pct": _safe_ach(sub.get("meets_required_rate")),
+        }
+
+    work = df.copy()
+    for col in ["category", "major_customer"]:
+        if col in work.columns:
+            series = work[col]
+            series = series.fillna("未設定").astype(str).str.strip()
+            series = series.replace({"": "未設定", "nan": "未設定", "None": "未設定"})
+            work[col] = series
+
+    benchmarks = {"overall": _calc_metrics(work)}
+
+    if "category" in work.columns:
+        by_category: Dict[str, Dict[str, float]] = {}
+        for label, subset in work.groupby("category", dropna=False):
+            by_category[_normalize_label(label)] = _calc_metrics(subset)
+        benchmarks["by_category"] = by_category
+    else:
+        benchmarks["by_category"] = {}
+
+    if "major_customer" in work.columns:
+        by_customer: Dict[str, Dict[str, float]] = {}
+        for label, subset in work.groupby("major_customer", dropna=False):
+            by_customer[_normalize_label(label)] = _calc_metrics(subset)
+        benchmarks["by_customer"] = by_customer
+    else:
+        benchmarks["by_customer"] = {}
+
+    return benchmarks
 
 
 def _match_product(query: str, df: pd.DataFrame) -> Optional[pd.Series]:
@@ -113,7 +210,7 @@ def _match_product(query: str, df: pd.DataFrame) -> Optional[pd.Series]:
 
 
 def _format_rate_comparison(
-    rates: Dict[str, float], df: pd.DataFrame, scenario: str
+    rates: Dict[str, float], df: pd.DataFrame, scenario: str, benchmarks: Dict[str, Any]
 ) -> str:
     fixed = _coerce_float(rates.get("fixed_total"))
     req_profit = _coerce_float(rates.get("required_profit_total"))
@@ -134,12 +231,23 @@ def _format_rate_comparison(
     total = len(df) if df is not None else 0
     if total:
         lines.append(f"- 参照データ: シナリオ『{scenario}』で取り込んだ {total} SKU の前提値を使用")
+    overall = (benchmarks or {}).get("overall") or {}
+    ach_rate = _coerce_float(overall.get("ach_rate_pct"))
+    avg_gap = _coerce_float(overall.get("avg_rate_gap"))
+    if not pd.isna(ach_rate):
+        lines.append(
+            f"- 達成状況: 全SKUの必要賃率達成率は {_format_percent(ach_rate)} です。"
+        )
+    if not pd.isna(avg_gap):
+        lines.append(
+            f"- 平均ギャップ: {_format_currency(avg_gap, '円/分', 2)} （正の値なら余裕、負の値なら不足）"
+        )
     lines.append("→ 必要賃率を下回ると目標利益に届かず、損益分岐賃率を下回ると固定費も回収できません。")
     return "\n".join(lines)
 
 
 def _format_required_rate_explanation(
-    rates: Dict[str, float], df: pd.DataFrame, scenario: str
+    rates: Dict[str, float], df: pd.DataFrame, scenario: str, benchmarks: Dict[str, Any]
 ) -> str:
     fixed = _coerce_float(rates.get("fixed_total"))
     req_profit = _coerce_float(rates.get("required_profit_total"))
@@ -155,12 +263,18 @@ def _format_required_rate_explanation(
     ]
     if total:
         lines.append(f"- 達成状況: {total} SKU 中 {meets} SKU ({meet_pct:.1f}%) が必要賃率を満たしています。")
+    overall = (benchmarks or {}).get("overall") or {}
+    raise_avg = _coerce_float(overall.get("avg_raise_needed"))
+    if not pd.isna(raise_avg) and raise_avg > 0:
+        lines.append(
+            f"- 平均の不足額: {_format_currency(raise_avg, '円/個')} の値上げ余地があります。"
+        )
     lines.append("→ 必要賃率を上回らない製品は付加価値向上や価格改定を検討してください。")
     return "\n".join(lines)
 
 
 def _format_break_even_explanation(
-    rates: Dict[str, float], df: pd.DataFrame, scenario: str
+    rates: Dict[str, float], df: pd.DataFrame, scenario: str, benchmarks: Dict[str, Any]
 ) -> str:
     fixed = _coerce_float(rates.get("fixed_total"))
     annual_minutes = _coerce_float(rates.get("annual_minutes"))
@@ -176,12 +290,22 @@ def _format_break_even_explanation(
     total = len(df) if df is not None else 0
     if total:
         lines.append(f"- 参照データ: シナリオ『{scenario}』の {total} SKU に基づく計算です。")
+    overall = (benchmarks or {}).get("overall") or {}
+    avg_va = _coerce_float(overall.get("avg_va_per_min"))
+    if not pd.isna(avg_va):
+        lines.append(
+            f"- 平均付加価値/分: {_format_currency(avg_va, '円/分', 2)} （全SKU平均）"
+        )
     lines.append("→ この賃率を下回ると固定費を回収できないため、最低ラインとして意識してください。")
     return "\n".join(lines)
 
 
 def _format_product_pricing(
-    row: pd.Series, rates: Dict[str, float], scenario: str
+    row: pd.Series,
+    rates: Dict[str, float],
+    scenario: str,
+    benchmarks: Dict[str, Any],
+    focus_raise: bool = False,
 ) -> str:
     req_rate = _coerce_float(rates.get("required_rate"))
     material = _coerce_float(row.get("material_unit_cost"))
@@ -193,8 +317,8 @@ def _format_product_pricing(
     gap_price = _coerce_float(row.get("price_gap_vs_required"))
     rate_gap = _coerce_float(row.get("rate_gap_vs_required"))
     va_per_min = _coerce_float(row.get("va_per_min"))
-    category = str(row.get("category", "") or "").strip()
-    customer = str(row.get("major_customer", "") or "").strip()
+    category = _normalize_label(row.get("category"))
+    customer = _normalize_label(row.get("major_customer"))
     name = str(row.get("product_name", "") or "").strip()
     number = str(row.get("product_no", "") or "").strip()
     label = " / ".join([part for part in [name, number] if part and part.lower() != "nan"])
@@ -212,37 +336,199 @@ def _format_product_pricing(
         lines.append(
             f"- 付加価値/分: {_format_currency(va_per_min, '円/分', 2)} → 必要賃率との差 {_format_currency(rate_gap, '円/分', 2)}"
         )
-    if category and category.lower() != "nan":
-        if customer and customer.lower() != "nan":
+    if category and category != "未設定":
+        if customer and customer != "未設定":
             lines.append(f"- カテゴリー/主要顧客: {category} / {customer}")
         else:
             lines.append(f"- カテゴリー: {category}")
-    elif customer and customer.lower() != "nan":
+    elif customer and customer != "未設定":
         lines.append(f"- 主要顧客: {customer}")
     lines.append(f"- 参照データ: シナリオ『{scenario}』で取り込んだ履歴から算出しました。")
     if not pd.isna(gap_price):
         if gap_price < 0:
-            lines.append(f"→ 必要販売単価まで {abs(gap_price):,.0f}円/個 の値上げが必要です。")
+            lines.append(
+                f"→ 必要販売単価まで {abs(gap_price):,.0f}円/個 の値上げ余地があります。"
+            )
         elif gap_price > 0:
             lines.append(f"→ 現在の売価は必要販売単価を {gap_price:,.0f}円/個 上回っています。")
         else:
             lines.append("→ 現在の売価は必要販売単価と一致しています。")
+    coaching = _build_coaching_lines(row, benchmarks, focus_raise)
+    if coaching:
+        lines.append("#### コーチングのヒント")
+        lines.extend(coaching)
     return "\n".join(lines)
 
 
+def _build_coaching_lines(
+    row: pd.Series, benchmarks: Dict[str, Any], focus_raise: bool
+) -> List[str]:
+    suggestions: List[str] = []
+    benchmarks = benchmarks or {}
+    actual = _coerce_float(row.get("actual_unit_price"))
+    required = _coerce_float(row.get("required_selling_price"))
+    rate_gap = _coerce_float(row.get("rate_gap_vs_required"))
+    category = _normalize_label(row.get("category"))
+    customer = _normalize_label(row.get("major_customer"))
+
+    overall = (benchmarks or {}).get("overall") or {}
+    overall_count = overall.get("sku_count")
+    avg_actual = _coerce_float(overall.get("avg_actual_price"))
+    avg_required = _coerce_float(overall.get("avg_required_price"))
+    ach_rate = _coerce_float(overall.get("ach_rate_pct"))
+    avg_raise = _coerce_float(overall.get("avg_raise_needed"))
+    overall_parts: List[str] = []
+    if not pd.isna(avg_actual):
+        overall_parts.append(f"実際売単価 {_format_currency(avg_actual, '円/個')}")
+    if not pd.isna(avg_required):
+        overall_parts.append(f"必要販売単価 {_format_currency(avg_required, '円/個')}")
+    if not pd.isna(ach_rate):
+        overall_parts.append(f"達成率 {_format_percent(ach_rate)}")
+    if overall_parts:
+        if isinstance(overall_count, (int, float)) and not pd.isna(overall_count) and overall_count:
+            prefix = f"- 直近 {int(overall_count)} SKU の平均: "
+        else:
+            prefix = "- 全SKU平均: "
+        suggestions.append(prefix + " / ".join(overall_parts))
+    if not pd.isna(avg_raise) and avg_raise > 0:
+        suggestions.append(
+            f"- 平均的に {_format_currency(avg_raise, '円/個')} の値上げ余地があります。段階的な価格改定を検討してください。"
+        )
+
+    category_metrics = (benchmarks.get("by_category") or {}).get(category)
+    if category_metrics and category != "未設定":
+        cat_actual = _coerce_float(category_metrics.get("avg_actual_price"))
+        cat_required = _coerce_float(category_metrics.get("avg_required_price"))
+        cat_ach = _coerce_float(category_metrics.get("ach_rate_pct"))
+        cat_raise = _coerce_float(category_metrics.get("avg_raise_needed"))
+        cat_parts: List[str] = []
+        if not pd.isna(cat_actual):
+            cat_parts.append(f"実際売単価 {_format_currency(cat_actual, '円/個')}")
+        if not pd.isna(cat_required):
+            cat_parts.append(f"必要販売単価 {_format_currency(cat_required, '円/個')}")
+        if not pd.isna(cat_ach):
+            cat_parts.append(f"達成率 {_format_percent(cat_ach)}")
+        if not pd.isna(cat_raise) and cat_raise > 0:
+            cat_parts.append(f"平均不足 {_format_currency(cat_raise, '円/個')}")
+        if cat_parts:
+            suggestions.append(
+                f"- カテゴリ『{category}』平均: " + " / ".join(cat_parts)
+            )
+        cat_top = _coerce_float(category_metrics.get("top_quartile_actual_price"))
+        if not pd.isna(cat_top) and not pd.isna(actual) and cat_top > actual:
+            diff = cat_top - actual
+            suggestions.append(
+                f"- 同カテゴリ上位25%の実際売単価は {_format_currency(cat_top, '円/個')}。現在との差 {diff:,.0f}円/個 が市場の実績です。"
+            )
+
+    customer_metrics = (benchmarks.get("by_customer") or {}).get(customer)
+    if customer_metrics and customer != "未設定":
+        cust_actual = _coerce_float(customer_metrics.get("avg_actual_price"))
+        cust_required = _coerce_float(customer_metrics.get("avg_required_price"))
+        cust_raise = _coerce_float(customer_metrics.get("avg_raise_needed"))
+        cust_parts: List[str] = []
+        if not pd.isna(cust_actual):
+            cust_parts.append(f"実際売単価 {_format_currency(cust_actual, '円/個')}")
+        if not pd.isna(cust_required):
+            cust_parts.append(f"必要販売単価 {_format_currency(cust_required, '円/個')}")
+        if not pd.isna(cust_raise) and cust_raise > 0:
+            cust_parts.append(f"平均不足 {_format_currency(cust_raise, '円/個')}")
+        if cust_parts:
+            suggestions.append(
+                f"- 主要顧客『{customer}』の平均: " + " / ".join(cust_parts)
+            )
+
+    if not pd.isna(required) and not pd.isna(actual):
+        diff = required - actual
+        if focus_raise and diff > 0:
+            suggestions.append(
+                f"- 必要販売単価との差 {diff:,.0f}円/個 をどう埋めるか、段階的な値上げやセット提案を検討しましょう。"
+            )
+        elif focus_raise and diff <= 0:
+            suggestions.append(
+                "- 既に必要販売単価を満たしています。価値訴求を強化した上で追加の値上げ可否を検証してください。"
+            )
+
+    if not pd.isna(rate_gap):
+        if rate_gap < 0:
+            suggestions.append(
+                f"- 必要賃率まで {abs(rate_gap):,.2f}円/分 不足。タクト短縮や材料費見直しでもギャップ解消が可能です。"
+            )
+        elif focus_raise:
+            suggestions.append(
+                "- 付加価値/分は必要賃率を満たしています。顧客との交渉では上位SKUの実績値を根拠に提示すると効果的です。"
+            )
+
+    return suggestions
+
+
+
 def _format_general_summary(
-    rates: Dict[str, float], df: pd.DataFrame, scenario: str
+    rates: Dict[str, float], df: pd.DataFrame, scenario: str, benchmarks: Dict[str, Any]
 ) -> str:
+    benchmarks = benchmarks or {}
+    if df is None:
+        df = pd.DataFrame()
     be_rate = _coerce_float(rates.get("break_even_rate"))
     req_rate = _coerce_float(rates.get("required_rate"))
-    total = len(df) if df is not None else 0
+    total = len(df)
     meets = _count_meets_required(df)
-    not_meet = total - meets
-    lines = [
+    not_meet = max(total - meets, 0)
+    lines: List[str] = [
         "### 主要指標サマリ",
         f"- 損益分岐賃率: {_format_currency(be_rate, '円/分', 2)}（式: 固定費計 ÷ 年間標準稼働分）",
         f"- 必要賃率: {_format_currency(req_rate, '円/分', 2)}（式: (固定費計 + 必要利益計) ÷ 年間標準稼働分）",
     ]
+
+    overall = (benchmarks.get("overall") or {})
+    avg_actual = _coerce_float(overall.get("avg_actual_price"))
+    avg_required = _coerce_float(overall.get("avg_required_price"))
+    ach_rate = _coerce_float(overall.get("ach_rate_pct"))
+    avg_raise = _coerce_float(overall.get("avg_raise_needed"))
+    summary_parts: List[str] = []
+    if not pd.isna(avg_actual):
+        summary_parts.append(f"実際売単価 {_format_currency(avg_actual, '円/個')}")
+    if not pd.isna(avg_required):
+        summary_parts.append(f"必要販売単価 {_format_currency(avg_required, '円/個')}")
+    if not pd.isna(ach_rate):
+        summary_parts.append(f"達成率 {_format_percent(ach_rate)}")
+    if summary_parts:
+        lines.append("- 全SKU平均: " + " / ".join(summary_parts))
+    if not pd.isna(avg_raise) and avg_raise > 0:
+        lines.append(
+            f"- 平均不足額: {_format_currency(avg_raise, '円/個')} の値上げ余地があります。"
+        )
+
+    category_bench = benchmarks.get("by_category") or {}
+    category_candidates: List[Tuple[str, float]] = []
+    for name, data in category_bench.items():
+        if name == "未設定":
+            continue
+        value = _coerce_float((data or {}).get("avg_raise_needed"))
+        if pd.isna(value) or value <= 0:
+            continue
+        category_candidates.append((name, value))
+    if category_candidates:
+        top_cat, top_value = max(category_candidates, key=lambda item: item[1])
+        lines.append(
+            f"- 値上げ余地が大きいカテゴリ: {top_cat}（平均不足 {_format_currency(top_value, '円/個')}）"
+        )
+
+    customer_bench = benchmarks.get("by_customer") or {}
+    customer_candidates: List[Tuple[str, float]] = []
+    for name, data in customer_bench.items():
+        if name == "未設定":
+            continue
+        value = _coerce_float((data or {}).get("avg_raise_needed"))
+        if pd.isna(value) or value <= 0:
+            continue
+        customer_candidates.append((name, value))
+    if customer_candidates:
+        top_customer, top_value = max(customer_candidates, key=lambda item: item[1])
+        lines.append(
+            f"- 値上げ余地が目立つ顧客: {top_customer}（平均不足 {_format_currency(top_value, '円/個')}）"
+        )
+
     if total:
         lines.append(f"- 対象データ: シナリオ『{scenario}』に {total} SKU を取り込み済み")
         lines.append(f"- 達成状況: 必要賃率達成 {meets} SKU / 未達 {not_meet} SKU")
@@ -252,12 +538,14 @@ def _format_general_summary(
             shortfalls["rate_gap_vs_required"] = gap_series
             shortfalls = shortfalls[shortfalls["rate_gap_vs_required"] < 0]
             shortfalls = shortfalls.sort_values("rate_gap_vs_required").head(3)
-            if not shortfalls.empty:
+            if not shortfalls.empty():
                 lines.append("### 必要賃率未達の上位SKU")
                 for _, row in shortfalls.iterrows():
                     pname = str(row.get("product_name", "") or "").strip()
                     pno = str(row.get("product_no", "") or "").strip()
-                    label = " / ".join([part for part in [pname, pno] if part and part.lower() != "nan"])
+                    label = " / ".join([
+                        part for part in [pname, pno] if part and part.lower() != "nan"
+                    ])
                     if not label:
                         label = "SKU"
                     gap_val = _coerce_float(row.get("rate_gap_vs_required"))
@@ -269,39 +557,145 @@ def _format_general_summary(
     return "\n".join(lines)
 
 
+def _format_benchmark_summary(benchmarks: Dict[str, Any], scenario: str) -> str:
+    benchmarks = benchmarks or {}
+    overall = benchmarks.get("overall") or {}
+    lines: List[str] = [
+        "### ベンチマークサマリ",
+        f"- 参照シナリオ: {scenario}",
+    ]
+
+    sku_count = overall.get("sku_count")
+    if isinstance(sku_count, (int, float)) and not pd.isna(sku_count):
+        lines.append(f"- 対象SKU数: {int(sku_count)} 件")
+
+    overall_parts: List[str] = []
+    avg_actual = _coerce_float(overall.get("avg_actual_price"))
+    avg_required = _coerce_float(overall.get("avg_required_price"))
+    avg_gap = _coerce_float(overall.get("avg_rate_gap"))
+    ach_rate = _coerce_float(overall.get("ach_rate_pct"))
+    avg_raise = _coerce_float(overall.get("avg_raise_needed"))
+    avg_va = _coerce_float(overall.get("avg_va_per_min"))
+    top_quartile_price = _coerce_float(overall.get("top_quartile_actual_price"))
+    top_quartile_va = _coerce_float(overall.get("top_quartile_va_per_min"))
+
+    if not pd.isna(avg_actual):
+        overall_parts.append(f"実際売単価 {_format_currency(avg_actual, '円/個')}")
+    if not pd.isna(avg_required):
+        overall_parts.append(f"必要販売単価 {_format_currency(avg_required, '円/個')}")
+    if not pd.isna(ach_rate):
+        overall_parts.append(f"必要賃率達成率 {_format_percent(ach_rate)}")
+    if overall_parts:
+        lines.append("- 全体平均: " + " / ".join(overall_parts))
+    if not pd.isna(avg_raise) and avg_raise > 0:
+        lines.append(
+            f"- 平均値上げ余地: {_format_currency(avg_raise, '円/個')}（必要販売単価との差）"
+        )
+    if not pd.isna(avg_gap):
+        lines.append(
+            f"- 必要賃率ギャップ平均: {_format_currency(avg_gap, '円/分', 2)}"
+        )
+    if not pd.isna(avg_va):
+        lines.append(f"- 平均付加価値/分: {_format_currency(avg_va, '円/分', 2)}")
+    if not pd.isna(top_quartile_price):
+        lines.append(
+            f"- 実際売単価 上位25%: {_format_currency(top_quartile_price, '円/個')}"
+        )
+    if not pd.isna(top_quartile_va):
+        lines.append(
+            f"- 付加価値/分 上位25%: {_format_currency(top_quartile_va, '円/分', 2)}"
+        )
+
+    def _summarize_dimension(
+        label: str, data: Dict[str, Dict[str, float]], metric: str
+    ) -> None:
+        if not data:
+            return
+        ranked: List[Tuple[str, float]] = []
+        for name, item in data.items():
+            if name == "未設定":
+                continue
+            value = _coerce_float((item or {}).get(metric))
+            if pd.isna(value):
+                continue
+            ranked.append((name, value))
+        if not ranked:
+            return
+        ranked.sort(key=lambda pair: pair[1], reverse=True)
+        top_name, top_value = ranked[0]
+        bottom_name, bottom_value = ranked[-1]
+        lines.append(
+            f"- {label}トップ: {top_name}（平均不足 {_format_currency(top_value, '円/個')}）"
+        )
+        if len(ranked) > 1:
+            lines.append(
+                f"- {label}ボトム: {bottom_name}（平均不足 {_format_currency(bottom_value, '円/個')}）"
+            )
+
+    _summarize_dimension("カテゴリ", benchmarks.get("by_category") or {}, "avg_raise_needed")
+    _summarize_dimension("主要顧客", benchmarks.get("by_customer") or {}, "avg_raise_needed")
+
+    lines.append(
+        "→ 未達の領域では値上げや原価改善の優先順位付けを検討しましょう。対象SKUを指定すると詳細な分解を返答します。"
+    )
+    return "\n".join(lines)
+
+
 def _generate_answer(
-    question: str, df_results: pd.DataFrame, rates: Dict[str, float], scenario: str
+    question: str,
+    df_results: pd.DataFrame,
+    rates: Dict[str, float],
+    scenario: str,
+    benchmarks: Dict[str, Any],
 ) -> str:
     if not question:
         return "質問が空のようです。知りたい内容を入力してください。"
     normalized = question.strip()
     normalized_lower = normalized.lower()
     product_row = _match_product(normalized, df_results)
-    keywords_price = any(k in normalized for k in ["価格", "単価", "いくら", "必要販売単価", "値段"]) or "price" in normalized_lower
-    if ("損益" in normalized and "必要" in normalized and ("違" in normalized or "差" in normalized or "比較" in normalized)):
-        return _format_rate_comparison(rates, df_results, scenario)
+    keywords_price = any(
+        k in normalized for k in ["価格", "単価", "いくら", "必要販売単価", "値段"]
+    ) or "price" in normalized_lower
+    wants_raise = any(
+        k in normalized for k in ["値上げ", "上げられる", "上げたい", "上げられます", "どの程度", "どれくらい"]
+    ) and ("価格" in normalized or "単価" in normalized or "値段" in normalized)
+    wants_benchmark = (
+        "業界平均" in normalized
+        or "ベンチマーク" in normalized_lower
+        or ("平均" in normalized and ("全体" in normalized or "カテゴリ" in normalized or "顧客" in normalized))
+    )
+    if "損益" in normalized and "必要" in normalized and (
+        "違" in normalized or "差" in normalized or "比較" in normalized
+    ):
+        return _format_rate_comparison(rates, df_results, scenario, benchmarks)
+    if product_row is not None and (wants_raise or (keywords_price and "不足" in normalized)):
+        return _format_product_pricing(product_row, rates, scenario, benchmarks, focus_raise=True)
+    if product_row is not None and (
+        "必要賃率" in normalized or "必要単価" in normalized or "付加価値" in normalized
+    ):
+        return _format_product_pricing(product_row, rates, scenario, benchmarks)
     if product_row is not None and keywords_price:
-        return _format_product_pricing(product_row, rates, scenario)
-    if product_row is not None and ("必要賃率" in normalized or "必要単価" in normalized or "付加価値" in normalized):
-        return _format_product_pricing(product_row, rates, scenario)
+        return _format_product_pricing(product_row, rates, scenario, benchmarks)
+    if wants_benchmark:
+        return _format_benchmark_summary(benchmarks, scenario)
     if "必要賃率" in normalized:
-        return _format_required_rate_explanation(rates, df_results, scenario)
+        return _format_required_rate_explanation(rates, df_results, scenario, benchmarks)
     if "損益分岐" in normalized:
-        return _format_break_even_explanation(rates, df_results, scenario)
+        return _format_break_even_explanation(rates, df_results, scenario, benchmarks)
     if product_row is not None:
-        return _format_product_pricing(product_row, rates, scenario)
+        return _format_product_pricing(product_row, rates, scenario, benchmarks)
     if keywords_price:
-        return (
-            "製品名または品番を含めると具体的な必要販売単価を計算できます。\n"
-            + _format_general_summary(rates, df_results, scenario)
-        )
+        prefix = "製品名または品番を含めると具体的な必要販売単価を計算できます。\n"
+        return prefix + _format_general_summary(rates, df_results, scenario, benchmarks)
     if "未達" in normalized or "ギャップ" in normalized:
-        return _format_general_summary(rates, df_results, scenario)
-    return _format_general_summary(rates, df_results, scenario)
-
+        return _format_general_summary(rates, df_results, scenario, benchmarks)
+    return _format_general_summary(rates, df_results, scenario, benchmarks)
 
 def _build_intro_message(
-    rates: Dict[str, float], df_results: pd.DataFrame, scenario: str
+    rates: Dict[str, float],
+    df_results: pd.DataFrame,
+    scenario: str,
+    benchmarks: Dict[str, Any],
 ) -> str:
     req_rate = _coerce_float(rates.get("required_rate"))
     be_rate = _coerce_float(rates.get("break_even_rate"))
@@ -315,6 +709,13 @@ def _build_intro_message(
         summary_part += f" {total} SKU 中 {not_meet} SKU が必要賃率未達です。"
     else:
         summary_part += " 製品データがまだ読み込まれていません。"
+    overall = (benchmarks or {}).get("overall") or {}
+    ach_rate = _coerce_float(overall.get("ach_rate_pct"))
+    avg_raise = _coerce_float(overall.get("avg_raise_needed"))
+    if not pd.isna(ach_rate):
+        summary_part += f" 全SKUの必要賃率達成率は {_format_percent(ach_rate)} です。"
+    if not pd.isna(avg_raise) and avg_raise > 0:
+        summary_part += f" 平均不足額は {_format_currency(avg_raise, '円/個')}。"
     return (
         f"こんにちは！賃率チャットボットです（シナリオ『{scenario}』を参照）。"
         f"{summary_part}損益分岐賃率との違いや製品ごとの必要販売単価など、気になる点を質問してください。"
@@ -421,6 +822,8 @@ if df_results.empty:
     st.error("製品データが読み込まれていません。まずは『データ入力』でExcelを取り込んでください。")
     st.stop()
 
+benchmarks = _compute_benchmarks(df_results)
+
 req_rate_val = _coerce_float(rate_results.get("required_rate"))
 be_rate_val = _coerce_float(rate_results.get("break_even_rate"))
 meets = _count_meets_required(df_results)
@@ -460,14 +863,16 @@ if not history:
     history.append(
         {
             "role": "assistant",
-            "content": _build_intro_message(rate_results, df_results, scenario_name),
+            "content": _build_intro_message(rate_results, df_results, scenario_name, benchmarks),
             "kind": "intro",
         }
     )
     st.session_state["chat_last_signature"] = signature
 else:
     if history[0].get("kind") == "intro" and st.session_state.get("chat_last_signature") != signature:
-        history[0]["content"] = _build_intro_message(rate_results, df_results, scenario_name)
+        history[0]["content"] = _build_intro_message(
+            rate_results, df_results, scenario_name, benchmarks
+        )
         st.session_state["chat_last_signature"] = signature
 
 pending_question = st.session_state.pop("chat_pending_question", None)
@@ -475,12 +880,16 @@ user_message = st.chat_input("賃率や価格について質問してくださ�
 
 if pending_question:
     history.append({"role": "user", "content": pending_question})
-    answer = _generate_answer(pending_question, df_results, rate_results, scenario_name)
+    answer = _generate_answer(
+        pending_question, df_results, rate_results, scenario_name, benchmarks
+    )
     history.append({"role": "assistant", "content": answer})
 
 if user_message:
     history.append({"role": "user", "content": user_message})
-    answer = _generate_answer(user_message, df_results, rate_results, scenario_name)
+    answer = _generate_answer(
+        user_message, df_results, rate_results, scenario_name, benchmarks
+    )
     history.append({"role": "assistant", "content": answer})
 
 for message in history:


### PR DESCRIPTION
## Summary
- add benchmark normalization utilities and aggregate metrics calculation for chat responses
- expand FAQ answer formatting to include benchmark summaries and coaching guidance
- update chat page initialization to compute benchmarks and pass them through the intro and answer flows

## Testing
- python -m compileall pages/04_チャットサポート.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d24d155b888323a867b091b1aa911e