### PR TITLE
Ensure local modules are imported before site packages

### DIFF
--- a/pages/01_データ入力.py
+++ b/pages/01_データ入力.py
@@ -1,6 +1,9 @@
 import sys
 from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+ROOT_DIR = str(Path(__file__).resolve().parents[1])
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 from datetime import date, datetime, timedelta
 

--- a/pages/03_標準賃率計算.py
+++ b/pages/03_標準賃率計算.py
@@ -1,6 +1,9 @@
 import sys
 from pathlib import Path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+ROOT_DIR = str(Path(__file__).resolve().parents[1])
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 import streamlit as st
 import pandas as pd

--- a/pages/04_チャットサポート.py
+++ b/pages/04_チャットサポート.py
@@ -1,7 +1,9 @@
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+ROOT_DIR = str(Path(__file__).resolve().parents[1])
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 import re
 from typing import Any, Dict, List, Optional, Tuple

--- a/pages/data/test_rates.py
+++ b/pages/data/test_rates.py
@@ -1,9 +1,12 @@
 import math
 import sys
 from pathlib import Path
+
 import pandas as pd
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+ROOT_DIR = str(Path(__file__).resolve().parents[1])
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 from standard_rate_core import (
     DEFAULT_PARAMS,

--- a/test_data_integrations.py
+++ b/test_data_integrations.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+ROOT_DIR = str(Path(__file__).resolve().parents[1])
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 from data_integrations import (  # noqa: E402
     IntegrationConfig,

--- a/test_rates.py
+++ b/test_rates.py
@@ -1,9 +1,12 @@
 import math
 import sys
 from pathlib import Path
+
 import pandas as pd
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+ROOT_DIR = str(Path(__file__).resolve().parents[1])
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 from standard_rate_core import (
     DEFAULT_PARAMS,


### PR DESCRIPTION
## Summary
- ensure each Streamlit page inserts the repository root at the front of sys.path before importing project modules
- apply the same sys.path handling in unit tests that load local modules

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d25b51c3748323a3afaaa640535e85