### PR TITLE
Add regulatory alerts, multilingual scenario analysis, and PDCA tools

### DIFF
--- a/data/external/legal_updates_sample.json
+++ b/data/external/legal_updates_sample.json
@@ -1,0 +1,46 @@
+[
+  {
+    "category": "最低賃金",
+    "region": "全国加重平均",
+    "effective_from": "2024-10-01",
+    "value": 1023,
+    "unit": "円/時",
+    "source": "厚生労働省",
+    "url": "https://www.mhlw.go.jp/stf/newpage_41425.html",
+    "last_updated": "2024-10-25",
+    "notes": "2024年度地域別最低賃金改定の全国加重平均です。"
+  },
+  {
+    "category": "最低賃金",
+    "region": "東京都",
+    "effective_from": "2024-10-01",
+    "value": 1113,
+    "unit": "円/時",
+    "source": "東京都産業労働局",
+    "url": "https://www.bousai.metro.tokyo.lg.jp/rousa/sokuhou/",
+    "last_updated": "2024-10-25",
+    "notes": "東京都の地域別最低賃金額。"
+  },
+  {
+    "category": "社会保険料率",
+    "region": "協会けんぽ（東京） 健康保険料率",
+    "effective_from": "2024-03-01",
+    "value": 9.98,
+    "unit": "％",
+    "source": "協会けんぽ",
+    "url": "https://www.kyoukaikenpo.or.jp/g3/cat310/sb3040/r6/20240301/",
+    "last_updated": "2024-03-05",
+    "notes": "一般保険料率（介護保険第2号被保険者を含む）。"
+  },
+  {
+    "category": "社会保険料率",
+    "region": "厚生年金保険料率",
+    "effective_from": "2024-09-01",
+    "value": 18.30,
+    "unit": "％",
+    "source": "日本年金機構",
+    "url": "https://www.nenkin.go.jp/service/kounen/hokenryo/",
+    "last_updated": "2024-08-20",
+    "notes": "標準報酬月額に対する労使折半前の料率。"
+  }
+]

--- a/legal_updates.py
+++ b/legal_updates.py
@@ -1,0 +1,170 @@
+"""Utilities for surfacing labour-law related updates inside the dashboard."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from functools import lru_cache
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import pandas as pd
+
+_DATA_DIR = Path(__file__).resolve().parent / "data" / "external"
+_DATA_FILE = _DATA_DIR / "legal_updates_sample.json"
+
+
+@dataclass
+class LegalUpdate:
+    """A single legal or regulatory update relevant for labour cost planning."""
+
+    category: str
+    region: str
+    effective_from: date
+    value: float
+    unit: str
+    source: str
+    url: Optional[str] = None
+    last_updated: Optional[date] = None
+    notes: Optional[str] = None
+
+
+def _normalise_records(records: List[Dict[str, Any]]) -> pd.DataFrame:
+    """Return a normalised :class:`~pandas.DataFrame` for downstream use."""
+
+    if not records:
+        columns = [
+            "category",
+            "region",
+            "effective_from",
+            "value",
+            "unit",
+            "source",
+            "url",
+            "last_updated",
+            "notes",
+        ]
+        return pd.DataFrame(columns=columns)
+
+    frame = pd.DataFrame(records)
+    for col in ("effective_from", "last_updated"):
+        if col in frame.columns:
+            frame[col] = pd.to_datetime(frame[col], errors="coerce").dt.date
+    numeric_cols = ["value"]
+    for col in numeric_cols:
+        if col in frame.columns:
+            frame[col] = pd.to_numeric(frame[col], errors="coerce")
+    return frame
+
+
+@lru_cache(maxsize=1)
+def _load_updates_cached(path_str: str) -> pd.DataFrame:
+    path = Path(path_str)
+    if not path.exists():
+        return _normalise_records([])
+    with path.open("r", encoding="utf-8") as fp:
+        try:
+            payload = json.load(fp)
+        except json.JSONDecodeError:
+            payload = []
+    if isinstance(payload, dict):
+        payload = [payload]
+    return _normalise_records(payload)
+
+
+def fetch_labor_standards_updates(source: Optional[Path] = None) -> pd.DataFrame:
+    """Load labour-law related updates (minimum wage, insurance rates, etc.)."""
+
+    target = source if source is not None else _DATA_FILE
+    df = _load_updates_cached(str(target))
+    # Return a copy so callers can mutate without affecting the cache entry.
+    return df.copy()
+
+
+def compute_average_hourly_wage(params: Dict[str, float], results: Dict[str, float]) -> float:
+    """Approximate the average hourly wage implied by the current parameters."""
+
+    annual_minutes = results.get("annual_minutes", 0.0)
+    if annual_minutes <= 0:
+        return 0.0
+    labor_cost = float(params.get("labor_cost", 0.0))
+    return labor_cost / annual_minutes * 60.0
+
+
+def build_compliance_alerts(
+    params: Dict[str, float],
+    results: Dict[str, float],
+    updates: pd.DataFrame,
+    *,
+    preferred_regions: Optional[Iterable[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Create structured alert payloads for the Streamlit UI."""
+
+    if updates is None or updates.empty:
+        return []
+
+    alerts: List[Dict[str, Any]] = []
+    preferred_regions = list(preferred_regions or [])
+
+    min_wage_df = updates[updates["category"] == "最低賃金"].copy()
+    if not min_wage_df.empty:
+        if preferred_regions:
+            min_wage_df = min_wage_df.sort_values(
+                by=["region", "effective_from"], ascending=[True, False]
+            )
+            preferred_df = min_wage_df[min_wage_df["region"].isin(preferred_regions)]
+            others_df = min_wage_df[~min_wage_df["region"].isin(preferred_regions)]
+            min_wage_df = pd.concat([preferred_df, others_df], ignore_index=True)
+            min_wage_df = min_wage_df.drop_duplicates("region")
+        latest_min = min_wage_df.sort_values(
+            by=["effective_from", "last_updated"], ascending=False
+        ).iloc[0]
+        hourly_wage = compute_average_hourly_wage(params, results)
+        target_value = float(latest_min.get("value", 0.0) or 0.0)
+        gap = hourly_wage - target_value
+        severity = "warning" if gap < 0 else "info"
+        alerts.append(
+            {
+                "category": "最低賃金",
+                "region": latest_min.get("region", ""),
+                "value": target_value,
+                "unit": latest_min.get("unit", ""),
+                "effective_from": latest_min.get("effective_from"),
+                "source": latest_min.get("source", ""),
+                "url": latest_min.get("url"),
+                "notes": latest_min.get("notes"),
+                "severity": severity,
+                "current_hourly_wage": hourly_wage,
+                "gap": gap,
+            }
+        )
+
+    social_df = updates[updates["category"] == "社会保険料率"].copy()
+    if not social_df.empty:
+        social_df = social_df.sort_values(
+            by=["region", "effective_from"], ascending=[True, False]
+        ).drop_duplicates("region")
+        for _, row in social_df.iterrows():
+            alerts.append(
+                {
+                    "category": "社会保険料率",
+                    "region": row.get("region", ""),
+                    "value": float(row.get("value", 0.0) or 0.0),
+                    "unit": row.get("unit", ""),
+                    "effective_from": row.get("effective_from"),
+                    "source": row.get("source", ""),
+                    "url": row.get("url"),
+                    "notes": row.get("notes"),
+                    "severity": "info",
+                }
+            )
+
+    return alerts
+
+
+__all__ = [
+    "LegalUpdate",
+    "fetch_labor_standards_updates",
+    "compute_average_hourly_wage",
+    "build_compliance_alerts",
+]


### PR DESCRIPTION
## Summary
- add a legal updates utility with sample data so the dashboard can surface minimum wage and insurance rate alerts
- internationalize the standard rate workflow with language toggles, interactive wage/hour sensitivity analysis, and curated learning resources
- capture continuous improvement feedback with a PDCA log while keeping static sensitivity charts available for PDF export

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d289f328488323b99f3e67e7489130