### PR TITLE
Add XlsxWriter dependency to fix Excel export error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ reportlab>=4.0.0
 streamlit_js_eval>=0.1.0
 plotly>=5.0.0
 openai>=1.0.0
+XlsxWriter>=3.1.0


### PR DESCRIPTION
## Summary
- add the XlsxWriter package to the app requirements so pandas can use the xlsxwriter ExcelWriter engine at runtime

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3f82b81ec83238aecad646e178613