### PR TITLE
Fix indentation for header block in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,8 +15,10 @@ render_sidebar_nav(page_key="home")
 
 header_col, help_col = st.columns([0.82, 0.18], gap="small")
 with header_col:
-st.title("製品賃率ダッシュボード")
-st.caption("📊 Excel（標賃 / R6.12）から賃率KPIを自動計算し、SKU別の達成状況を可視化します。")
+    st.title("製品賃率ダッシュボード")
+    st.caption(
+        "📊 Excel（標賃 / R6.12）から賃率KPIを自動計算し、SKU別の達成状況を可視化します。"
+    )
 
 render_help_button("home", container=help_col)
 


### PR DESCRIPTION
## Summary
- indent the Streamlit header block inside the layout column context manager to avoid runtime syntax errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d512cbcab48323b92f7cf17520b6e5