### PR TITLE
Revamp branding theme and navigation

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,6 +1,7 @@
 [theme]
-primaryColor = "#0B1F3B"
-backgroundColor = "#F7F8FA"
+base = "dark"
+primaryColor = "#003366"
+backgroundColor = "#F5F7FA"
 secondaryBackgroundColor = "#FFFFFF"
-textColor = "#1A1A1A"
-font = "sans serif"
+textColor = "#1B2733"
+font = "Noto Sans JP"

--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+import html
+
 import streamlit as st
 from components import (
     apply_user_theme,
@@ -6,21 +8,65 @@ from components import (
     render_page_tutorial,
     render_stepper,
     render_sidebar_nav,
+    render_top_navbar,
 )
 
-st.set_page_config(page_title="賃率ダッシュボード", layout="wide")
+st.set_page_config(
+    page_title="賃率ダッシュボード",
+    layout="wide",
+    initial_sidebar_state="collapsed",
+)
 apply_user_theme()
 
 render_sidebar_nav(page_key="home")
 
-header_col, help_col = st.columns([0.82, 0.18], gap="small")
-with header_col:
-    st.title("製品賃率ダッシュボード")
-    st.caption(
-        "📊 Excel（標賃 / R6.12）から賃率KPIを自動計算し、SKU別の達成状況を可視化します。"
+render_top_navbar(
+    page_key="home",
+    page_title="製品賃率ダッシュボード",
+    subtitle="Product Rate Intelligence Suite",
+    phase_label="Phase 3",
+)
+
+hero_container = st.container()
+hero_container.markdown("<section class='hero-card'>", unsafe_allow_html=True)
+hero_cols = hero_container.columns([0.62, 0.38], gap="large")
+with hero_cols[0]:
+    st.markdown("<div class='hero-card__badge'>PHASE 3 / BRAND REFRESH</div>", unsafe_allow_html=True)
+    st.markdown("<h1>製品賃率ダッシュボード</h1>", unsafe_allow_html=True)
+    st.markdown(
+        "<p class='hero-card__lead'>📊 標準賃率シートをアップロードするだけで、KPIカード・達成状況ヒートマップ・感度分析がワンクリックで揃います。経営層向けの上質なレポート体験を届けましょう。</p>",
+        unsafe_allow_html=True,
+    )
+    st.markdown(
+        """
+        <div class="hero-card__meta">
+            <span class="hero-chip">自動KPI集約</span>
+            <span class="hero-chip">プレミアムUX</span>
+            <span class="hero-chip">レスポンシブ対応</span>
+        </div>
+        """,
+        unsafe_allow_html=True,
     )
 
-render_help_button("home", container=help_col)
+with hero_cols[1]:
+    st.markdown("<div class='content-card'>", unsafe_allow_html=True)
+    st.markdown("<h4 class='content-card__title'>エグゼクティブスナップショット</h4>", unsafe_allow_html=True)
+    st.markdown(
+        "<p class='content-card__body'>最新の入力データから推計した主要KPIをサマリ表示します。詳細はダッシュボードタブでゲージやヒートマップとして深掘りできます。</p>",
+        unsafe_allow_html=True,
+    )
+    metric_cols = st.columns(2, gap="medium")
+    with metric_cols[0]:
+        st.metric("SKU達成率", "82%", "先月比 +5pt")
+    with metric_cols[1]:
+        st.metric("稼働率", "94%", "計画比 +2pt")
+    st.markdown("<div class='content-card__cta'>", unsafe_allow_html=True)
+    help_container = st.container()
+    render_help_button("home", container=help_container)
+    st.markdown("</div>", unsafe_allow_html=True)
+    st.markdown("</div>", unsafe_allow_html=True)
+
+hero_container.markdown("</section>", unsafe_allow_html=True)
 
 render_onboarding()
 
@@ -30,8 +76,7 @@ render_page_tutorial("home")
 # Progress stepper for wizard flow
 render_stepper(0)
 
-st.markdown("### 3ステップではじめましょう")
-cols = st.columns(3, gap="large")
+st.markdown("<h2>3ステップではじめましょう</h2>", unsafe_allow_html=True)
 steps = [
     (
         "1. データを準備",
@@ -39,18 +84,23 @@ steps = [
     ),
     (
         "2. ダッシュボードで把握",
-        "自動生成されたKPIカードとグラフでSKUの状況を確認します。",
+        "KPIカード・ゲージ・ヒートマップでSKUの達成状況を素早く確認します。",
     ),
     (
         "3. 標準賃率を検証",
-        "ウィザードで固定費や稼働条件を見直し、必要賃率を計算します。",
+        "ウィザードで固定費や稼働条件を見直し、必要賃率と感度をシミュレーションします。",
     ),
 ]
-for col, (title, body) in zip(cols, steps):
-    with col:
-        st.markdown(f"#### {title}")
-        st.caption(body)
-
+step_cards = "".join(
+    f"""
+    <div class='content-card'>
+        <div class='content-card__title'>{html.escape(title)}</div>
+        <p class='content-card__body'>{html.escape(body)}</p>
+    </div>
+    """
+    for title, body in steps
+)
+st.markdown(f"<div class='card-grid card-grid--three'>{step_cards}</div>", unsafe_allow_html=True)
 st.caption("※ 詳細ガイドや用語集は必要なときに展開して確認できます。")
 
 
@@ -61,23 +111,41 @@ def _go_to_data_page() -> None:
         st.switch_page("pages/01_データ入力.py")
     except Exception:
         st.session_state["nav_intent"] = "data"
+        st.experimental_set_query_params(next="data")
         st.experimental_rerun()
 
 
-cta_col1, cta_col2 = st.columns([0.6, 0.4], gap="large")
-with cta_col1:
-    st.subheader("主なページ")
+cta_container = st.container()
+cta_cols = cta_container.columns([0.58, 0.42], gap="large")
+with cta_cols[0]:
+    st.markdown("<div class='content-card'>", unsafe_allow_html=True)
+    st.markdown("<h4 class='content-card__title'>主なページ</h4>", unsafe_allow_html=True)
     st.markdown(
-        "- ① データ入力: Excel取込 / サンプル / 直接編集\n"
-        "- ② ダッシュボード: KPIカードと詳細グラフ\n"
-        "- ③ 標準賃率計算: 5ステップウィザード\n"
-        "- ④ チャット / FAQ: AIボットとマニュアル"
+        """
+        <div class="content-card__body">
+            <ul>
+                <li>① データ入力: Excel取込 / サンプル / 直接編集</li>
+                <li>② ダッシュボード: KPIカードと詳細グラフ</li>
+                <li>③ 標準賃率計算: 5ステップウィザード</li>
+                <li>④ チャット / FAQ: AIボットとマニュアル</li>
+            </ul>
+        </div>
+        """,
+        unsafe_allow_html=True,
     )
-with cta_col2:
-    st.subheader("まずはデータを準備しましょう")
-    st.caption("テンプレートを確認したら、アップロードかサンプル利用を選んでダッシュボードの土台を作成します。")
+    st.markdown("</div>", unsafe_allow_html=True)
+with cta_cols[1]:
+    st.markdown("<div class='content-card'>", unsafe_allow_html=True)
+    st.markdown("<h4 class='content-card__title'>まずはデータを準備</h4>", unsafe_allow_html=True)
+    st.markdown(
+        "<p class='content-card__body'>テンプレートを確認したら、アップロードかサンプル利用を選んでダッシュボードの土台を作成します。</p>",
+        unsafe_allow_html=True,
+    )
+    st.markdown("<div class='content-card__cta'>", unsafe_allow_html=True)
     st.button("👉 データ入力へ進む", use_container_width=True, on_click=_go_to_data_page)
+    st.markdown("</div>", unsafe_allow_html=True)
     st.caption("※ 初回はExcelを読み込むと自動的にダッシュボードへ遷移します。")
+    st.markdown("</div>", unsafe_allow_html=True)
 
 with st.expander("導入メリットの目安（フェルミ推定）", expanded=False):
     st.markdown(
@@ -87,17 +155,22 @@ with st.expander("導入メリットの目安（フェルミ推定）", expanded
         "> 合計で月 **約2.5時間** の意思決定時間短縮が見込めます。"
     )
 
-st.write("主要機能はこちらから移動できます。")
-
-c1, c2, c3, c4 = st.columns(4)
-with c1:
+st.markdown("<div class='content-card'>", unsafe_allow_html=True)
+st.markdown("<h4 class='content-card__title'>クイックアクセス</h4>", unsafe_allow_html=True)
+st.markdown(
+    "<p class='content-card__body'>主要機能はこちらから移動できます。</p>",
+    unsafe_allow_html=True,
+)
+link_cols = st.columns(4, gap="large")
+with link_cols[0]:
     st.page_link("pages/01_データ入力.py", label="① データ入力 & 取り込み", icon="📥")
-with c2:
+with link_cols[1]:
     st.page_link("pages/02_ダッシュボード.py", label="② ダッシュボード", icon="📊")
-with c3:
+with link_cols[2]:
     st.page_link("pages/03_標準賃率計算.py", label="③ 標準賃率 計算/感度分析", icon="🧮")
-with c4:
+with link_cols[3]:
     st.page_link("pages/04_チャットサポート.py", label="④ チャット/FAQ", icon="💬")
+st.markdown("</div>", unsafe_allow_html=True)
 
 st.info(
     "まずは『データ入力 & 取り込み』で Excel を読み込むかサンプルを使用し、"

--- a/components.py
+++ b/components.py
@@ -23,19 +23,18 @@ _ACCESSIBILITY_PREFS_FLAG = "_accessibility_prefs_loaded"
 
 _THEME_PALETTES: Dict[str, Dict[str, str]] = {
     "標準（ブルー）": {
-        "background": "#F7F8FA",
+        "background": "#F5F7FA",
         "surface": "#FFFFFF",
-        "text": "#1A1A1A",
-        "primary": "#0B1F3B",
-        "secondary": "#5A6B7A",
-        "accent": "#1E88E5",
-        "border": "#D1DAE5",
-        "muted": "#5A6B7A",
-        # 成功・警告・エラーカラーはトーンを20%白に寄せ、目に優しくしています。
-        "success": "#69B36C",  # lighten(#43A047, 20%)
-        "warning": "#FCA333",  # lighten(#FB8C00, 20%)
-        "danger": "#EA615D",  # lighten(#E53935, 20%)
-        "description": "濃紺と淡いグレーを基調とした知的で信頼感のある標準配色です。",
+        "text": "#1B2733",
+        "primary": "#003366",
+        "secondary": "#2F3B4A",
+        "accent": "#4A7AB7",
+        "border": "#D4DBE6",
+        "muted": "#607089",
+        "success": "#2F8F5B",
+        "warning": "#D89B3E",
+        "danger": "#C75C5C",
+        "description": "ネイビーとチャコールを基調にしたハイエンドコンサル風の落ち着いた配色です。",
     },
     "高コントラスト（濃紺×白）": {
         "background": "#0F172A",
@@ -89,6 +88,64 @@ _FONT_SCALE_OPTIONS: Dict[str, float] = {
     "特大": 1.3,
     "超特大": 1.45,
 }
+
+_PRIMARY_NAV_ITEMS: List[Dict[str, str]] = [
+    {"key": "home", "label": "ホーム", "icon": "🏠", "page": "app.py"},
+    {
+        "key": "data",
+        "label": "データ入力",
+        "icon": "📥",
+        "page": "pages/01_データ入力.py",
+    },
+    {
+        "key": "dashboard",
+        "label": "ダッシュボード",
+        "icon": "📊",
+        "page": "pages/02_ダッシュボード.py",
+    },
+    {
+        "key": "standard_rate",
+        "label": "標準賃率",
+        "icon": "🧮",
+        "page": "pages/03_標準賃率計算.py",
+    },
+    {
+        "key": "chat",
+        "label": "チャット/FAQ",
+        "icon": "💬",
+        "page": "pages/04_チャットサポート.py",
+    },
+]
+
+
+def _navigate_to_page(page_path: str, intent: str) -> None:
+    """Navigate to ``page_path`` with a query parameter fallback."""
+
+    try:
+        st.switch_page(page_path)
+    except Exception:
+        st.session_state["nav_intent"] = intent
+        st.experimental_set_query_params(next=intent)
+        st.experimental_rerun()
+
+
+def _sync_sidebar_visibility(is_open: bool) -> None:
+    """Synchronise the sidebar visibility class on the document ``body``."""
+
+    state_class = "open" if is_open else "closed"
+    st.markdown(
+        f"""
+        <script>
+        (function() {{
+            const rootDoc = (window.parent && window.parent.document) ? window.parent.document : document;
+            if (!rootDoc || !rootDoc.body) return;
+            rootDoc.body.classList.remove('nav-sidebar-open', 'nav-sidebar-closed');
+            rootDoc.body.classList.add('nav-sidebar-{state_class}');
+        }})();
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
 
 
 def _call_accessibility_js(expression: str, suffix: str) -> Optional[Any]:
@@ -609,11 +666,15 @@ def _build_theme_css(theme: Dict[str, str], font_scale: float) -> str:
     primary = theme.get("primary", theme.get("text", "#0B1F3B"))
     secondary = theme.get("secondary", theme.get("muted", "#5A6B7A"))
     accent = theme.get("accent", "#1E88E5")
-    font_stack = "'Inter', 'Source Sans 3', 'Hiragino Sans', 'Noto Sans JP', sans-serif"
-    numeric_font_stack = "'Roboto Mono', 'Inter', 'Source Sans 3', 'Hiragino Sans', 'Noto Sans JP', monospace"
+    font_stack = (
+        "'Noto Sans JP', 'Roboto', 'Hiragino Sans', 'Yu Gothic UI', 'Segoe UI', sans-serif"
+    )
+    numeric_font_stack = (
+        "'Roboto Mono', 'Roboto', 'Noto Sans JP', 'Hiragino Sans', monospace"
+    )
     return f"""
     <style>
-    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Sans+3:wght@400;600;700&family=Roboto+Mono:wght@500;600;700&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@500;700&display=swap');
     :root {{
         --app-bg: {theme['background']};
         --app-surface: {theme['surface']};
@@ -651,20 +712,25 @@ def _build_theme_css(theme: Dict[str, str], font_scale: float) -> str:
         max-width: 1280px;
     }}
     h1 {{
-        font-size: 28px;
-        line-height: 1.3;
+        font-size: 30px;
+        line-height: 1.28;
+        color: var(--color-primary);
     }}
     h2 {{
-        font-size: 22px;
-        line-height: 1.35;
+        font-size: 24px;
+        line-height: 1.32;
+        color: var(--color-primary);
     }}
     h3 {{
-        font-size: 18px;
-        line-height: 1.4;
+        font-size: 19px;
+        line-height: 1.38;
+        color: var(--color-primary);
     }}
-    h4 {{ font-size: calc(var(--app-font-base) * 1.1); }}
-    h1, h2, h3, h4, h5, h6 {{
+    h4 {{
+        font-size: calc(var(--app-font-base) * 1.08);
         color: var(--app-text);
+    }}
+    h1, h2, h3, h4, h5, h6 {{
         font-weight: 700;
         letter-spacing: 0.01em;
         font-family: var(--font-sans);
@@ -681,6 +747,303 @@ def _build_theme_css(theme: Dict[str, str], font_scale: float) -> str:
     }}
     strong {{
         color: var(--app-text);
+    }}
+    .top-nav {{
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        background: linear-gradient(90deg, rgba(0, 51, 102, 0.94), rgba(0, 51, 102, 0.88));
+        padding: calc(var(--spacing-unit) * 1.75) calc(var(--spacing-unit) * 2.25);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 6px 12px rgba(5, 21, 40, 0.12);
+        backdrop-filter: blur(6px);
+    }}
+    .top-nav [data-testid="column"] > div {{
+        display: flex;
+        align-items: center;
+        height: 100%;
+    }}
+    .top-nav__brand {{
+        display: flex;
+        align-items: center;
+        gap: calc(var(--spacing-unit) * 1.5);
+        color: #F5F7FA;
+    }}
+    .top-nav__logo {{
+        width: 46px;
+        height: 46px;
+        border-radius: 12px;
+        background: #F5F7FA;
+        color: var(--color-primary);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 700;
+        font-size: 1.05rem;
+        letter-spacing: 0.08em;
+    }}
+    .top-nav__brand-text {{
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }}
+    .top-nav__brand-title {{
+        font-size: 0.9rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        opacity: 0.75;
+    }}
+    .top-nav__brand-page {{
+        font-size: 1.12rem;
+        font-weight: 600;
+    }}
+    .top-nav__brand-sub {{
+        font-size: 0.85rem;
+        opacity: 0.68;
+    }}
+    .top-nav__links {{
+        display: flex;
+        justify-content: center;
+        width: 100%;
+        gap: calc(var(--spacing-unit) * 0.75);
+    }}
+    .top-nav__link {{
+        display: inline-flex;
+        flex: 1 1 auto;
+    }}
+    .top-nav__link .stButton > button {{
+        width: 100%;
+        background: transparent;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        color: #F5F7FA;
+        border-radius: 999px;
+        font-weight: 600;
+        font-size: 0.9rem;
+        padding: calc(var(--spacing-unit) * 0.75) calc(var(--spacing-unit) * 1.75);
+        transition: all 0.18s ease;
+        box-shadow: none;
+    }}
+    .top-nav__link .stButton > button:hover {{
+        background: rgba(255, 255, 255, 0.12);
+        transform: translateY(-1px);
+        box-shadow: 0 6px 16px rgba(5, 21, 40, 0.18);
+    }}
+    .top-nav__link.is-active .stButton > button {{
+        background: #F5F7FA;
+        color: var(--color-primary);
+        border-color: #F5F7FA;
+        box-shadow: 0 6px 16px rgba(5, 21, 40, 0.22);
+    }}
+    .top-nav__actions {{
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        gap: calc(var(--spacing-unit) * 1.5);
+        width: 100%;
+    }}
+    .top-nav__user {{
+        display: inline-flex;
+        align-items: center;
+        gap: calc(var(--spacing-unit) * 1);
+        color: #F5F7FA;
+    }}
+    .top-nav__avatar {{
+        width: 38px;
+        height: 38px;
+        border-radius: 50%;
+        background: rgba(245, 247, 250, 0.18);
+        border: 1px solid rgba(245, 247, 250, 0.35);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+        letter-spacing: 0.05em;
+    }}
+    .top-nav__user-detail {{
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        font-size: 0.8rem;
+        line-height: 1.2;
+    }}
+    .top-nav__user-detail span:last-child {{
+        font-size: 0.92rem;
+        font-weight: 600;
+    }}
+    .top-nav__toggle .stButton > button {{
+        border-radius: 999px;
+        background: rgba(245, 247, 250, 0.12);
+        border: 1px solid rgba(245, 247, 250, 0.35);
+        color: #F5F7FA;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        padding: calc(var(--spacing-unit) * 0.75) calc(var(--spacing-unit) * 1.5);
+    }}
+    .top-nav__toggle .stButton > button:hover {{
+        background: rgba(245, 247, 250, 0.22);
+    }}
+    body.nav-sidebar-closed [data-testid="stSidebar"] {{
+        transform: translateX(-110%);
+        pointer-events: none;
+    }}
+    body.nav-sidebar-open [data-testid="stSidebar"] {{
+        transform: translateX(0);
+        pointer-events: all;
+        box-shadow: 0 18px 35px rgba(11, 31, 59, 0.16);
+    }}
+    body.nav-sidebar-open::after {{
+        content: "";
+        position: fixed;
+        inset: 0;
+        background: rgba(11, 31, 59, 0.35);
+        z-index: 40;
+    }}
+    @media (min-width: 1040px) {{
+        body.nav-sidebar-closed [data-testid="stSidebar"] {{
+            transform: translateX(0);
+            pointer-events: all;
+        }}
+        body.nav-sidebar-open::after {{
+            display: none;
+        }}
+    }}
+    @media (max-width: 960px) {{
+        .top-nav {{
+            padding: calc(var(--spacing-unit) * 1.5) calc(var(--spacing-unit) * 1.75);
+        }}
+        .top-nav [data-testid="column"] > div {{
+            justify-content: center;
+            margin-bottom: calc(var(--spacing-unit) * 1.25);
+        }}
+        .top-nav__links {{
+            flex-wrap: wrap;
+        }}
+        .top-nav__link {{
+            flex: 1 1 45%;
+        }}
+        .top-nav__actions {{
+            justify-content: center;
+        }}
+    }}
+    @media (max-width: 640px) {{
+        .top-nav__link {{
+            flex: 1 1 100%;
+        }}
+        .top-nav__actions {{
+            flex-direction: column;
+            align-items: stretch;
+            gap: calc(var(--spacing-unit) * 1);
+        }}
+        .top-nav__user {{
+            justify-content: center;
+        }}
+        .top-nav__toggle .stButton > button {{
+            width: 100%;
+        }}
+    }}
+    .hero-card {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: calc(var(--spacing-unit) * 3);
+        padding: calc(var(--spacing-unit) * 3);
+        background: var(--app-surface);
+        border-radius: 20px;
+        border: 1px solid rgba(0, 51, 102, 0.12);
+        box-shadow: 0 18px 38px rgba(5, 21, 40, 0.12);
+        margin-bottom: calc(var(--spacing-unit) * 3);
+    }}
+    .hero-card__badge {{
+        display: inline-flex;
+        align-items: center;
+        gap: calc(var(--spacing-unit) * 0.5);
+        background: rgba(0, 51, 102, 0.12);
+        color: var(--color-primary);
+        border-radius: 999px;
+        padding: calc(var(--spacing-unit) * 0.5) calc(var(--spacing-unit) * 1.25);
+        font-size: 0.8rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+    }}
+    .hero-card__lead {{
+        font-size: 1rem;
+        color: var(--app-text);
+        line-height: 1.75;
+        max-width: 520px;
+        margin-top: calc(var(--spacing-unit) * 1.25);
+    }}
+    .hero-card__meta {{
+        margin-top: calc(var(--spacing-unit) * 2);
+        display: flex;
+        gap: calc(var(--spacing-unit) * 1.5);
+        flex-wrap: wrap;
+    }}
+    .hero-chip {{
+        background: rgba(0, 51, 102, 0.08);
+        border-radius: 12px;
+        padding: calc(var(--spacing-unit) * 0.6) calc(var(--spacing-unit) * 1.25);
+        font-size: 0.82rem;
+        color: var(--color-primary);
+        font-weight: 600;
+    }}
+    .card-grid {{
+        display: grid;
+        gap: calc(var(--spacing-unit) * 2.5);
+        margin: calc(var(--spacing-unit) * 2.5) 0;
+    }}
+    .card-grid--three {{
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }}
+    .content-card {{
+        background: var(--app-surface);
+        border-radius: 18px;
+        border: 1px solid rgba(0, 51, 102, 0.08);
+        box-shadow: 0 16px 32px rgba(5, 21, 40, 0.08);
+        padding: calc(var(--spacing-unit) * 2.5);
+        display: flex;
+        flex-direction: column;
+        gap: calc(var(--spacing-unit) * 1.5);
+        min-height: 210px;
+    }}
+    .content-card__title {{
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: var(--color-primary);
+        margin: 0;
+    }}
+    .content-card__body {{
+        font-size: 0.95rem;
+        color: var(--app-text);
+        line-height: 1.7;
+    }}
+    .content-card__cta {{
+        margin-top: auto;
+    }}
+    .content-card__cta .stButton > button {{
+        width: 100%;
+    }}
+    .kpi-board {{
+        display: grid;
+        gap: calc(var(--spacing-unit) * 2);
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }}
+    [data-testid="stMetric"] > div {{
+        background: var(--app-surface);
+        border-radius: 16px;
+        border: 1px solid rgba(0, 51, 102, 0.08);
+        box-shadow: 0 10px 26px rgba(5, 21, 40, 0.12);
+        padding: calc(var(--spacing-unit) * 1.75);
+        gap: calc(var(--spacing-unit) * 1.25);
+    }}
+    [data-testid="stMetric"] label {{
+        color: var(--app-muted) !important;
+        font-size: 0.86rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }}
+    [data-testid="stMetric"] span {{
+        font-size: 1.65rem !important;
+        color: var(--color-primary) !important;
+        font-family: var(--font-number);
     }}
     [data-testid="stHeader"] {{
         background-color: var(--app-surface);
@@ -756,28 +1119,28 @@ def _build_theme_css(theme: Dict[str, str], font_scale: float) -> str:
         outline-offset: 2px;
     }}
     [data-testid="stMetric"] {{
-        background: var(--app-surface);
-        border-radius: 10px;
-        padding: calc(var(--spacing-unit) * 1.5) calc(var(--spacing-unit) * 1.75);
-        box-shadow: 0 2px 4px rgba(11, 31, 59, 0.08);
-        border: 1px solid rgba(11, 31, 59, 0.08);
-        gap: calc(var(--spacing-unit) * 0.5);
-        align-items: flex-start;
+        background: transparent;
+        border: none;
+        padding: 0;
+        box-shadow: none;
+        align-items: stretch;
     }}
     [data-testid="stMetricLabel"] {{
-        color: var(--color-secondary) !important;
-        font-size: calc(var(--app-font-base) * 0.9);
-        letter-spacing: 0.02em;
+        color: var(--app-muted) !important;
+        font-size: 0.82rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
     }}
     [data-testid="stMetricValue"] {{
         font-family: var(--font-number);
         font-variant-numeric: tabular-nums;
         font-feature-settings: "tnum" 1, "lnum" 1;
         color: var(--color-primary) !important;
-        font-size: calc(var(--app-font-base) * 1.25);
+        font-size: 1.6rem;
+        line-height: 1.25;
     }}
     [data-testid="stMetricDelta"] {{
-        font-size: calc(var(--app-font-base) * 0.92);
+        font-size: 0.9rem;
         font-weight: 600;
     }}
     [data-testid="stAppViewContainer"] .stAlert {{
@@ -922,6 +1285,97 @@ def get_active_theme_palette() -> Dict[str, str]:
     _ensure_theme_state()
     theme_key = st.session_state.get("ui_theme", _DEFAULT_THEME_KEY)
     return _THEME_PALETTES.get(theme_key, _THEME_PALETTES[_DEFAULT_THEME_KEY]).copy()
+
+
+def render_top_navbar(
+    *,
+    page_key: str,
+    page_title: str,
+    subtitle: Optional[str] = None,
+    phase_label: Optional[str] = None,
+) -> None:
+    """Render a sticky top navigation bar with brand, links and user menu."""
+
+    _ensure_theme_state()
+    if not st.session_state.get("_theme_css_injected"):
+        apply_user_theme()
+
+    st.session_state.setdefault("_navbar_sidebar_open", False)
+
+    nav_container = st.container()
+    nav_container.markdown("<header class='top-nav'>", unsafe_allow_html=True)
+    brand_col, links_col, actions_col = nav_container.columns([0.34, 0.4, 0.26], gap="large")
+
+    with brand_col:
+        badge = phase_label or "Product Rate Intelligence"
+        subtitle_html = f"<span class='top-nav__brand-sub'>{html.escape(subtitle)}</span>" if subtitle else ""
+        brand_markup = f"""
+            <div class="top-nav__brand">
+                <div class="top-nav__logo">PR</div>
+                <div class="top-nav__brand-text">
+                    <span class="top-nav__brand-title">{html.escape(badge)}</span>
+                    <span class="top-nav__brand-page">{html.escape(page_title)}</span>
+                    {subtitle_html}
+                </div>
+            </div>
+        """
+        st.markdown(brand_markup, unsafe_allow_html=True)
+
+    with links_col:
+        st.markdown("<div class='top-nav__links'>", unsafe_allow_html=True)
+        link_columns = st.columns(len(_PRIMARY_NAV_ITEMS), gap="small")
+        for col, item in zip(link_columns, _PRIMARY_NAV_ITEMS):
+            active_class = " is-active" if item["key"] == page_key else ""
+            with col:
+                st.markdown(f"<div class='top-nav__link{active_class}'>", unsafe_allow_html=True)
+                button_label = f"{item['icon']} {item['label']}"
+                if st.button(
+                    button_label,
+                    key=f"top_nav_btn_{item['key']}",
+                    use_container_width=True,
+                ):
+                    _navigate_to_page(item["page"], item["key"])
+                st.markdown("</div>", unsafe_allow_html=True)
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    with actions_col:
+        actions_col.markdown("<div class='top-nav__actions'>", unsafe_allow_html=True)
+        user_col, toggle_col = actions_col.columns([0.68, 0.32], gap="small")
+
+        user_profile: Dict[str, Any] = st.session_state.get("user_profile", {})  # type: ignore[assignment]
+        display_name = str(user_profile.get("display_name") or user_profile.get("name") or "ゲスト")
+        organisation = str(user_profile.get("company") or "Premium Workspace")
+        initials_source = "".join(ch for ch in display_name if ch.isalnum())
+        initials = (initials_source[:2] or "PR").upper()
+        user_markup = f"""
+            <div class="top-nav__user">
+                <span class="top-nav__avatar">{html.escape(initials)}</span>
+                <div class="top-nav__user-detail">
+                    <span>{html.escape(organisation)}</span>
+                    <span>{html.escape(display_name)}</span>
+                </div>
+            </div>
+        """
+        with user_col:
+            st.markdown(user_markup, unsafe_allow_html=True)
+
+        with toggle_col:
+            toggle_state = bool(st.session_state.get("_navbar_sidebar_open", False))
+            toggle_label = "✕ 閉じる" if toggle_state else "☰ メニュー"
+            st.markdown("<div class='top-nav__toggle'>", unsafe_allow_html=True)
+            if st.button(
+                toggle_label,
+                key="top_nav_toggle",
+                help="サイドバーの表示/非表示を切り替えます。",
+                use_container_width=True,
+            ):
+                st.session_state["_navbar_sidebar_open"] = not toggle_state
+            st.markdown("</div>", unsafe_allow_html=True)
+
+        actions_col.markdown("</div>", unsafe_allow_html=True)
+
+    nav_container.markdown("</header>", unsafe_allow_html=True)
+    _sync_sidebar_visibility(bool(st.session_state.get("_navbar_sidebar_open", False)))
 
 
 def render_help_button(

--- a/pages/01_データ入力.py
+++ b/pages/01_データ入力.py
@@ -43,6 +43,7 @@ from components import (
     render_page_tutorial,
     render_stepper,
     render_sidebar_nav,
+    render_top_navbar,
 )
 from offline import (
     mark_restore_notice_shown,
@@ -99,6 +100,13 @@ def _load_sample_workbook(path: str) -> Optional[pd.ExcelFile]:
 apply_user_theme()
 
 render_sidebar_nav(page_key="data")
+
+render_top_navbar(
+    page_key="data",
+    page_title="① データ入力 & 取り込み",
+    subtitle="データ品質チェックとテンプレ管理",
+    phase_label="Phase 3",
+)
 
 header_col, help_col = st.columns([0.78, 0.22], gap="small")
 with header_col:

--- a/pages/02_ダッシュボード.py
+++ b/pages/02_ダッシュボード.py
@@ -33,6 +33,7 @@ from components import (
     render_page_tutorial,
     render_stepper,
     render_sidebar_nav,
+    render_top_navbar,
     render_indicator_cards,
 )
 from offline import restore_session_state_from_cache, sync_offline_cache
@@ -49,15 +50,15 @@ from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, Tabl
 from openai import OpenAI
 
 PASTEL_PALETTE = [
-    "#0B1F3B",
-    "#1E88E5",
-    "#5A6B7A",
-    "#69B36C",
-    "#FCA333",
-    "#EA615D",
+    "#003366",
+    "#4A7AB7",
+    "#2F3B4A",
+    "#2F8F5B",
+    "#D89B3E",
+    "#C75C5C",
 ]
-PASTEL_ACCENT = "#1E88E5"
-PASTEL_BG = "#F7F8FA"
+PASTEL_ACCENT = "#4A7AB7"
+PASTEL_BG = "#F5F7FA"
 _PASTEL_THEME_NAME = "pastel_mck"
 _PASTEL_THEME_CONFIG = {
     "config": {
@@ -3422,6 +3423,13 @@ def _generate_dashboard_comment(
         return f"AIコメント生成に失敗しました: {exc}"
 
 render_sidebar_nav(page_key="dashboard")
+
+render_top_navbar(
+    page_key="dashboard",
+    page_title="② ダッシュボード",
+    subtitle="経営判断に直結するKPIレポート",
+    phase_label="Phase 3",
+)
 
 header_col, help_col = st.columns([0.76, 0.24], gap="small")
 with header_col:

--- a/pages/03_標準賃率計算.py
+++ b/pages/03_標準賃率計算.py
@@ -17,6 +17,7 @@ from components import (
     render_page_tutorial,
     render_stepper,
     render_sidebar_nav,
+    render_top_navbar,
 )
 import os
 from io import BytesIO
@@ -870,6 +871,13 @@ apply_user_theme()
 restore_session_state_from_cache()
 
 render_sidebar_nav(page_key="standard_rate")
+
+render_top_navbar(
+    page_key="standard_rate",
+    page_title="③ 標準賃率 計算/感度分析",
+    subtitle="必要賃率と利益配分のシミュレーション",
+    phase_label="Phase 3",
+)
 
 if "df_products_raw" not in st.session_state or st.session_state.get("df_products_raw") is None:
     st.info("データがまだ取り込まれていません。『① データ入力』でExcelを読み込むかサンプルを使用してください。")

--- a/pages/04_チャットサポート.py
+++ b/pages/04_チャットサポート.py
@@ -17,6 +17,7 @@ from components import (
     render_onboarding,
     render_page_tutorial,
     render_sidebar_nav,
+    render_top_navbar,
 )
 from offline import restore_session_state_from_cache, sync_offline_cache
 from standard_rate_core import DEFAULT_PARAMS, compute_rates, sanitize_params
@@ -804,6 +805,13 @@ apply_user_theme()
 
 restore_session_state_from_cache()
 render_sidebar_nav(page_key="chat")
+
+render_top_navbar(
+    page_key="chat",
+    page_title="④ チャット / FAQ",
+    subtitle="AIガイドとナレッジベースへのアクセス",
+    phase_label="Phase 3",
+)
 
 header_col, help_col = st.columns([0.78, 0.22], gap="small")
 with header_col:

--- a/pages/data/app.py
+++ b/pages/data/app.py
@@ -1,9 +1,20 @@
 import streamlit as st
-from components import render_stepper, render_sidebar_nav
+from components import render_stepper, render_sidebar_nav, render_top_navbar
 
-st.set_page_config(page_title="賃率ダッシュボード", layout="wide")
+st.set_page_config(
+    page_title="賃率ダッシュボード",
+    layout="wide",
+    initial_sidebar_state="collapsed",
+)
 
 render_sidebar_nav()
+
+render_top_navbar(
+    page_key="home",
+    page_title="製品賃率ダッシュボード",
+    subtitle="Product Rate Intelligence Suite",
+    phase_label="Phase 3",
+)
 
 st.title("製品賃率ダッシュボード")
 st.caption("📊 Excel（標賃 / R6.12）から賃率KPIを自動計算し、SKU別の達成状況を可視化します。")


### PR DESCRIPTION
## Summary
- apply a navy and charcoal inspired branding theme with unified typography, card styling, and responsive refinements for metrics and layout components
- introduce a reusable top navigation bar with brand identity, page shortcuts, and sidebar toggle and adopt it across the multipage app alongside the updated color palette
- refresh the home experience with a hero snapshot, three-step card grid, CTA cards, and a quick-access panel that align with the new look

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d537b6c3e883238bc84d5f7aa64e40