### PR TITLE
Fix focus validation preview crash

### DIFF
--- a/pages/01_データ入力.py
+++ b/pages/01_データ入力.py
@@ -527,6 +527,7 @@ if should_trigger_load:
     error_issue_keys: Set[Tuple[str, str]] = set()
     warning_issue_keys: Set[Tuple[str, str]] = set()
     highlight_html: Optional[str] = None
+    focus_validation = st.session_state.pop("focus_validation", False)
 
     if not detail_df.empty:
         for _, issue in detail_df.iterrows():


### PR DESCRIPTION
## Summary
- pull the `focus_validation` flag from `st.session_state` before using it so validation preview opens safely

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e773ac79b88323937160538cde28c7